### PR TITLE
pull updated UDD and Reporter, propagate errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>Bridge-Reporter</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeUserDataDownloadService</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>Bridge-Reporter</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -70,6 +70,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -90,11 +95,6 @@
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <version>1.8.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.sagebionetworks.bridge</groupId>
-            <artifactId>java-sdk</artifactId>
-            <version>0.11.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
@@ -7,9 +7,6 @@ import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.config.PropertiesConfig;
 import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.heartbeat.HeartbeatLogger;
-import org.sagebionetworks.bridge.sdk.ClientInfo;
-import org.sagebionetworks.bridge.sdk.ClientProvider;
-import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
 import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 import org.sagebionetworks.bridge.sqs.SqsHelper;
 import org.sagebionetworks.bridge.workerPlatform.multiplexer.BridgeWorkerPlatformSqsCallback;
@@ -25,8 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 // These configs get credentials from the default credential chain. For developer desktops, this is ~/.aws/credentials.
 // For EC2 instances, this happens transparently.
@@ -40,13 +35,6 @@ public class SpringConfig {
     private static final String CONFIG_FILE = "BridgeWorkerPlatform.conf";
     private static final String DEFAULT_CONFIG_FILE = CONFIG_FILE;
     private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/" + CONFIG_FILE;
-
-    // ClientProvider needs to be statically configured.
-    static {
-        // set client info
-        ClientInfo clientInfo = new ClientInfo.Builder().withAppName("BridgeWorkerPlatform").withAppVersion(1).build();
-        ClientProvider.setClientInfo(clientInfo);
-    }
 
     @Bean(name = "workerPlatformConfigProperties")
     public Config bridgeConfig() {
@@ -63,15 +51,6 @@ public class SpringConfig {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
-    }
-
-    @Bean
-    public SignInCredentials bridgeWorkerCredentials() {
-        Config config = bridgeConfig();
-        String study = config.get("bridge.worker.study");
-        String email = config.get("bridge.worker.email");
-        String password = config.get("bridge.worker.password");
-        return new SignInCredentials(study, email, password);
     }
 
     @Bean
@@ -109,11 +88,6 @@ public class SpringConfig {
         sqsWorker.setSleepTimeMillis(config.getInt("workerPlatform.request.sqs.sleep.time.millis"));
         sqsWorker.setSqsHelper(sqsHelper());
         return sqsWorker;
-    }
-
-    @Bean(name = "platformExecutorService")
-    public ExecutorService platformExecutorService() {
-        return Executors.newFixedThreadPool(bridgeConfig().getInt("threadpool.worker.count"));
     }
 
     @Bean(name="workerPlatformSynapseClient")

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/WorkerLauncher.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/WorkerLauncher.java
@@ -40,6 +40,7 @@ public class WorkerLauncher implements CommandLineRunner {
         LOG.info("Worker Platform Starting heartbeat...");
         new Thread(heartbeatLogger).start();
 
+        // TODO: make this multi-threaded
         LOG.info("Worker Platform Starting poll SQS worker...");
         new Thread(pollSqsWorkers).start();
     }

--- a/src/main/resources/BridgeWorkerPlatform.conf
+++ b/src/main/resources/BridgeWorkerPlatform.conf
@@ -10,7 +10,6 @@ synapse.api.key = your-api-key-here
 
 workerPlatform.request.sqs.sleep.time.millis=125
 heartbeat.interval.minutes=30
-threadpool.worker.count=16
 
 local.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
 dev.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-dev


### PR DESCRIPTION
Changes:
* pulled in bug fixes from UDD and Reporter
* fix version conflict with GSON that was preventing runtime
* remove unused old Java SDK
* propagate errors back to the PollSqsWorker - This has the side effect of making Worker Platform single-threaded.

Testing done (both UDD and Reporter):
* injected errors, verified message is cycled back to SQS
* Bad Request errors, verified these are *not* cycled back to SQS
* normal case