### PR TITLE
Switch to using new Bridge Platform worker queue

### DIFF
--- a/src/main/resources/BridgeWorkerPlatform.conf
+++ b/src/main/resources/BridgeWorkerPlatform.conf
@@ -12,6 +12,6 @@ workerPlatform.request.sqs.sleep.time.millis=125
 heartbeat.interval.minutes=30
 
 local.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
-dev.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-dev
-uat.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-uat
-prod.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-prod
+dev.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-k27gydakh8-stack-AWSEBWorkerQueue-10LFYQ4O9F8D6
+uat.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-4tmrkvfypx-stack-AWSEBWorkerQueue-4PPUVDIUC5N9
+prod.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-7p7a3qcye3-stack-AWSEBWorkerQueue-1TRGQFVV1SU17


### PR DESCRIPTION
The infra for BridgeWorkerPlatform app is now automated with
BridgeWorkerPlatform-infra[1] repo.  This project uses cloudformation
to setup the EB worker env and SQS queues. We should switch to using
this queue and deprecate the manually created SQS queues.

[1] https://github.com/Sage-Bionetworks/BridgeWorkerPlatform-infra