### PR TITLE
synapsePrincipalId is a long, not string

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
@@ -144,8 +144,8 @@ public class SpringConfig {
     }
 
     @Bean(name="synapsePrincipalId")
-    public String synapsePrincipalId() {
-        return bridgeConfig().get("synapse.principal.id");
+    public long synapsePrincipalId() {
+        return bridgeConfig().getInt("synapse.principal.id");
     }
 
     @Bean(name = Constants.SERVICE_TYPE_REPORTER)


### PR DESCRIPTION
Oddly enough, String worked fine locally, but not in Elastic Beanstalk.