### PR TITLE
BRIDGE-2024: monitor with new relic

### DIFF
--- a/ebextensions/newrelic.config
+++ b/ebextensions/newrelic.config
@@ -1,0 +1,24 @@
+files:
+  "/etc/newrelic-infra.yml" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      # New Relic Infrastructure configuration file
+      # Reference:
+      #   https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-config-file-template-newrelic-infrayml
+      log_file: /var/log/newrelic-infra.log
+      log_to_stdout: false
+container_commands:
+# Setup NR infrastructure agent config
+  "11SetNRInfraLicenseKey":
+    command: "echo -e \"license_key: $NEW_RELIC_LICENSE_KEY\" >> /etc/newrelic-infra.yml"
+  "12SetNRJInfraDisplayName":
+    command: "echo -e \"\ndisplay_name: $NEW_RELIC_APP_NAME\" >> /etc/newrelic-infra.yml"
+# Install NR infrastructure agent
+  "13SetupInfraAgentRepo":
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
+  "14UpdateInfraAgentYumCache":
+    command: sudo yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
+  "20InstallInfraAgent":
+    command: sudo yum install newrelic-infra -y

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,19 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <directory>ebextensions</directory>
+                            <targetPath>.ebextensions</targetPath>
+                            <filtering>true</filtering>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>1.8</version>


### PR DESCRIPTION
Setup agent to allow EC2 monitoring with new relic.
Note: only works when deployed to EB bridgeworker-* Envs