### PR TITLE
BRIDGE-2024: Stream tomcat log to cloudwatch

### DIFF
--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -1,0 +1,32 @@
+###################################################################################################
+#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
+#### the Log Stream name as the instance id. The following files are examples of logs that will be
+#### streamed to CloudWatch Logs in near real time:
+#### 
+#### /var/log/tomcat8/catalina.out
+#### 
+#### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
+#### the "Logs" link on the left. The Log Group name will follow this format:
+####
+#### /aws/elasticbeanstalk/<environment name>/<full log name path>
+####
+#### Please note this configuration can be used additionally to the "Log Streaming" feature:
+#### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+###################################################################################################
+
+files:
+  "/etc/awslogs/config/tomcatlogs.conf" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      [/var/log/tomcat8/catalina.out]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/catalina.out"]]}`
+      log_stream_name={instance_id}
+      file=/var/log/tomcat8/catalina.out*
+
+commands:
+  "01_restart_awslogs":
+    command: service awslogs restart
+  "02_set_retention_policy":
+    command: aws --region `{"Ref":"AWS::Region"}` logs put-retention-policy --log-group-name `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/catalina.out"]]}` --retention-in-days 90

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,19 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <directory>ebextensions</directory>
+                            <targetPath>.ebextensions</targetPath>
+                            <filtering>true</filtering>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>1.8</version>


### PR DESCRIPTION
BridgeWorker runs in a tomcat process and its application log is sent
to the tomcat log.  Use cloudwatch log integration[1] to stream the
application logs to cloudwatch so we can monitor messages in the log.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html