### PR TITLE
So that all worker processes run in the worker app, some dependencies have to be advanced.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
             <artifactId>aws-java-sdk-sqs</artifactId>
             <version>${aws.version}</version>
         </dependency>
-        <!-- Recent additions of AWS libs don't include a recent enough version of httpclient. -->
+        <!-- Recent additions of AWS libs require a more recent version of httpclient than is being 
+	    pulled in by dependencies. -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <aws.version>1.10.56</aws.version>
+        <aws.version>1.11.198</aws.version>
         <jackson.version>2.8.3</jackson.version>
         <java.version>1.8</java.version>
         <logback.version>1.1.6</logback.version>
@@ -45,6 +45,12 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
             <version>${aws.version}</version>
+        </dependency>
+        <!-- Recent additions of AWS libs don't include a recent enough version of httpclient. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -84,7 +90,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.9</version>
+            <version>2.7.13</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>
@@ -99,7 +105,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeUserDataDownloadService</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>


### PR DESCRIPTION
This should probably be merged before UDD version updates.