### PR TITLE
randomized messages and decouple data group logic

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/notification/helper/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/helper/DynamoHelper.java
@@ -28,9 +28,9 @@ public class DynamoHelper {
     static final String KEY_EXCLUDED_DATA_GROUP_SET = "excludedDataGroupSet";
     static final String KEY_FINISH_TIME = "finishTime";
     static final String KEY_MESSAGE = "message";
-    static final String KEY_MISSED_CUMULATIVE_MESSAGES = "missedCumulativeActivitiesMessagesByDataGroup";
-    static final String KEY_MISSED_EARLY_MESSAGES = "missedEarlyActivitiesMessagesByDataGroup";
-    static final String KEY_MISSED_LATER_MESSAGES = "missedLaterActivitiesMessagesByDataGroup";
+    static final String KEY_MISSED_CUMULATIVE_MESSAGES = "missedCumulativeActivitiesMessagesList";
+    static final String KEY_MISSED_EARLY_MESSAGES = "missedEarlyActivitiesMessagesList";
+    static final String KEY_MISSED_LATER_MESSAGES = "missedLaterActivitiesMessagesList";
     static final String KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_START = "notificationBlackoutDaysFromStart";
     static final String KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_END = "notificationBlackoutDaysFromEnd";
     static final String KEY_NOTIFICATION_TIME = "notificationTime";
@@ -39,7 +39,6 @@ public class DynamoHelper {
     static final String KEY_NUM_MISSED_DAYS_TO_NOTIFY = "numMissedDaysToNotify";
     static final String KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY = "numMissedConsecutiveDaysToNotify";
     static final String KEY_PREBURST_MESSAGES = "preburstMessagesByDataGroup";
-    static final String KEY_REQUIRED_DATA_GROUPS = "requiredDataGroupsOneOfSet";
     static final String KEY_REQUIRED_SUBPOPULATION_GUID_SET = "requiredSubpopulationGuidSet";
     static final String KEY_STUDY_ID = "studyId";
     static final String KEY_TAG = "tag";
@@ -82,6 +81,7 @@ public class DynamoHelper {
     }
 
     /** Gets the notification config for the given study. This method caches results for 5 minutes. */
+    @SuppressWarnings("DefaultAnnotationParam")
     @Cacheable(lifetime = 5, unit = TimeUnit.MINUTES)
     public WorkerConfig getNotificationConfigForStudy(String studyId) {
         Item item = ddbNotificationConfigTable.getItem(KEY_STUDY_ID, studyId);
@@ -91,16 +91,15 @@ public class DynamoHelper {
         workerConfig.setBurstTaskId(item.getString(KEY_BURST_TASK_ID));
         workerConfig.setEarlyLateCutoffDays(item.getInt(KEY_EARLY_LATE_CUTOFF_DAYS));
         workerConfig.setExcludedDataGroupSet(item.getStringSet(KEY_EXCLUDED_DATA_GROUP_SET));
-        workerConfig.setMissedCumulativeActivitiesMessagesByDataGroup(item.getMap(KEY_MISSED_CUMULATIVE_MESSAGES));
-        workerConfig.setMissedEarlyActivitiesMessagesByDataGroup(item.getMap(KEY_MISSED_EARLY_MESSAGES));
-        workerConfig.setMissedLaterActivitiesMessagesByDataGroup(item.getMap(KEY_MISSED_LATER_MESSAGES));
+        workerConfig.setMissedCumulativeActivitiesMessagesList(item.getList(KEY_MISSED_CUMULATIVE_MESSAGES));
+        workerConfig.setMissedEarlyActivitiesMessagesList(item.getList(KEY_MISSED_EARLY_MESSAGES));
+        workerConfig.setMissedLaterActivitiesMessagesList(item.getList(KEY_MISSED_LATER_MESSAGES));
         workerConfig.setNotificationBlackoutDaysFromStart(item.getInt(KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_START));
         workerConfig.setNotificationBlackoutDaysFromEnd(item.getInt(KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_END));
         workerConfig.setNumActivitiesToCompleteBurst(item.getInt(KEY_NUM_ACTIVITIES_TO_COMPLETE));
         workerConfig.setNumMissedConsecutiveDaysToNotify(item.getInt(KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY));
         workerConfig.setNumMissedDaysToNotify(item.getInt(KEY_NUM_MISSED_DAYS_TO_NOTIFY));
         workerConfig.setPreburstMessagesByDataGroup(item.getMap(KEY_PREBURST_MESSAGES));
-        workerConfig.setRequiredDataGroupsOneOfSet(item.getStringSet(KEY_REQUIRED_DATA_GROUPS));
         workerConfig.setRequiredSubpopulationGuidSet(item.getStringSet(KEY_REQUIRED_SUBPOPULATION_GUID_SET));
         return workerConfig;
     }

--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
@@ -169,7 +169,7 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
                 .filter(activityEvent -> workerConfig.getBurstStartEventIdSet().contains(activityEvent.getEventId()))
                 .collect(Collectors.toList());
 
-        // Find the upcoming burst, if a burst is coming up tomorrow.
+        // If today's the start of a burst, send the pre-burst notification.
         ActivityEvent upcomingBurstEvent = findUpcomingActivityBurstEvent(date, participant,
                 filteredActivityEventList);
         if (upcomingBurstEvent != null) {
@@ -275,8 +275,8 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
         DateTimeZone timeZone = DateUtils.parseZoneFromOffsetString(participant.getTimeZone());
 
         for (ActivityEvent oneActivityEvent : activityEventList) {
-            if (oneActivityEvent.getTimestamp().withZone(timeZone).toLocalDate().minusDays(1).equals(date)) {
-                // If the burst start is tomorrow, then we've found it!
+            if (oneActivityEvent.getTimestamp().withZone(timeZone).toLocalDate().equals(date)) {
+                // If the burst start is today, then we've found it!
                 return oneActivityEvent;
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
@@ -169,7 +169,7 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
                 .filter(activityEvent -> workerConfig.getBurstStartEventIdSet().contains(activityEvent.getEventId()))
                 .collect(Collectors.toList());
 
-        // If today's the start of a burst, send the pre-burst notification.
+        // Find the upcoming burst, if a burst is coming up tomorrow.
         ActivityEvent upcomingBurstEvent = findUpcomingActivityBurstEvent(date, participant,
                 filteredActivityEventList);
         if (upcomingBurstEvent != null) {
@@ -275,8 +275,8 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
         DateTimeZone timeZone = DateUtils.parseZoneFromOffsetString(participant.getTimeZone());
 
         for (ActivityEvent oneActivityEvent : activityEventList) {
-            if (oneActivityEvent.getTimestamp().withZone(timeZone).toLocalDate().equals(date)) {
-                // If the burst start is today, then we've found it!
+            if (oneActivityEvent.getTimestamp().withZone(timeZone).toLocalDate().minusDays(1).equals(date)) {
+                // If the burst start is tomorrow, then we've found it!
                 return oneActivityEvent;
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/WorkerConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/WorkerConfig.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.notification.worker;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -13,16 +15,15 @@ public class WorkerConfig {
     private String burstTaskId;
     private int earlyLateCutoffDays;
     private Set<String> excludedDataGroupSet = ImmutableSet.of();
-    private Map<String, String> missedCumulativeActivitiesMessagesByDataGroup = ImmutableMap.of();
-    private Map<String, String> missedEarlyActivitiesMessagesByDataGroup = ImmutableMap.of();
-    private Map<String, String> missedLaterActivitiesMessagesByDataGroup = ImmutableMap.of();
+    private List<String> missedCumulativeActivitiesMessagesList = ImmutableList.of();
+    private List<String> missedEarlyActivitiesMessagesList = ImmutableList.of();
+    private List<String> missedLaterActivitiesMessagesList = ImmutableList.of();
     private int notificationBlackoutDaysFromStart;
     private int notificationBlackoutDaysFromEnd;
     private int numActivitiesToCompleteBurst;
     private int numMissedConsecutiveDaysToNotify;
     private int numMissedDaysToNotify;
-    private Map<String, String> preburstMessagesByDataGroup = ImmutableMap.of();
-    private Set<String> requiredDataGroupsOneOfSet = ImmutableSet.of();
+    private Map<String, List<String>> preburstMessagesByDataGroup = ImmutableMap.of();
     private Set<String> requiredSubpopulationGuidSet = ImmutableSet.of();
 
     /** The length of the study burst, in days. */
@@ -82,48 +83,45 @@ public class WorkerConfig {
     }
 
     /**
-     * Messages to send if the participant misses a cumulative total of activities during this study burst, keyed by
-     * data group. The keys in this set should match the keys in {@link #getRequiredDataGroupsOneOfSet}.
+     * Messages to send if the participant misses a cumulative total of activities during this study burst. Worker
+     * will pick one at random.
      */
-    public Map<String, String> getMissedCumulativeActivitiesMessagesByDataGroup() {
-        return missedCumulativeActivitiesMessagesByDataGroup;
+    public List<String> getMissedCumulativeActivitiesMessagesList() {
+        return missedCumulativeActivitiesMessagesList;
     }
 
-    /** @see #getMissedCumulativeActivitiesMessagesByDataGroup */
-    public void setMissedCumulativeActivitiesMessagesByDataGroup(
-            Map<String, String> missedCumulativeActivitiesMessagesByDataGroup) {
-        this.missedCumulativeActivitiesMessagesByDataGroup = missedCumulativeActivitiesMessagesByDataGroup != null ?
-                ImmutableMap.copyOf(missedCumulativeActivitiesMessagesByDataGroup) : ImmutableMap.of();
+    /** @see #getMissedCumulativeActivitiesMessagesList */
+    public void setMissedCumulativeActivitiesMessagesList(List<String> missedCumulativeActivitiesMessagesList) {
+        this.missedCumulativeActivitiesMessagesList = missedCumulativeActivitiesMessagesList != null ?
+                ImmutableList.copyOf(missedCumulativeActivitiesMessagesList) : ImmutableList.of();
     }
 
     /**
-     * Messages to send if the participant misses consecutive activities early in the study burst, keyed by data group.
-     * The keys in this set should match the keys in {@link #getRequiredDataGroupsOneOfSet}.
+     * Messages to send if the participant misses consecutive activities early in the study burst. Worker will pick one
+     * at random.
      */
-    public Map<String, String> getMissedEarlyActivitiesMessagesByDataGroup() {
-        return missedEarlyActivitiesMessagesByDataGroup;
+    public List<String> getMissedEarlyActivitiesMessagesList() {
+        return missedEarlyActivitiesMessagesList;
     }
 
-    /** @see #getMissedEarlyActivitiesMessagesByDataGroup */
-    public void setMissedEarlyActivitiesMessagesByDataGroup(
-            Map<String, String> missedEarlyActivitiesMessagesByDataGroup) {
-        this.missedEarlyActivitiesMessagesByDataGroup = missedEarlyActivitiesMessagesByDataGroup != null ?
-                ImmutableMap.copyOf(missedEarlyActivitiesMessagesByDataGroup) : ImmutableMap.of();
+    /** @see #getMissedEarlyActivitiesMessagesList */
+    public void setMissedEarlyActivitiesMessagesList(List<String> missedEarlyActivitiesMessagesList) {
+        this.missedEarlyActivitiesMessagesList = missedEarlyActivitiesMessagesList != null ?
+                ImmutableList.copyOf(missedEarlyActivitiesMessagesList) : ImmutableList.of();
     }
 
     /**
-     * Messages to send if the participant misses consecutive activities late in the study burst, keyed by data group.
-     * The keys in this set should match the keys in {@link #getRequiredDataGroupsOneOfSet}.
+     * Messages to send if the participant misses consecutive activities late in the study burst. Worker will pick one
+     * at random.
      */
-    public Map<String, String> getMissedLaterActivitiesMessagesByDataGroup() {
-        return missedLaterActivitiesMessagesByDataGroup;
+    public List<String> getMissedLaterActivitiesMessagesList() {
+        return missedLaterActivitiesMessagesList;
     }
 
-    /** @see #getMissedLaterActivitiesMessagesByDataGroup */
-    public void setMissedLaterActivitiesMessagesByDataGroup(
-            Map<String, String> missedLaterActivitiesMessagesByDataGroup) {
-        this.missedLaterActivitiesMessagesByDataGroup = missedLaterActivitiesMessagesByDataGroup != null ?
-                ImmutableMap.copyOf(missedLaterActivitiesMessagesByDataGroup) : ImmutableMap.of();
+    /** @see #getMissedLaterActivitiesMessagesList */
+    public void setMissedLaterActivitiesMessagesList(List<String> missedLaterActivitiesMessagesList) {
+        this.missedLaterActivitiesMessagesList = missedLaterActivitiesMessagesList != null ?
+                ImmutableList.copyOf(missedLaterActivitiesMessagesList) : ImmutableList.of();
     }
 
     /** Number of days at the start of the study burst where we don't send notifications. */
@@ -177,28 +175,17 @@ public class WorkerConfig {
     }
 
     /**
-     * Messages to send before the start of the study burst, keyed by data group. The keys in this set should match the
-     * keys in {@link #getRequiredDataGroupsOneOfSet}.
+     * Messages to send before the start of the study burst, keyed by data group. Each entry is a list of possible
+     * messages, and the worker picks one of those messages at random.
      */
-    public Map<String, String> getPreburstMessagesByDataGroup() {
+    public Map<String, List<String>> getPreburstMessagesByDataGroup() {
         return preburstMessagesByDataGroup;
     }
 
     /** @see #getPreburstMessagesByDataGroup */
-    public void setPreburstMessagesByDataGroup(Map<String, String> preburstMessagesByDataGroup) {
+    public void setPreburstMessagesByDataGroup(Map<String, List<String>> preburstMessagesByDataGroup) {
         this.preburstMessagesByDataGroup = preburstMessagesByDataGroup != null ?
                 ImmutableMap.copyOf(preburstMessagesByDataGroup) : ImmutableMap.of();
-    }
-
-    /** Participant must be in one of these data groups to receive notifications. */
-    public Set<String> getRequiredDataGroupsOneOfSet() {
-        return requiredDataGroupsOneOfSet;
-    }
-
-    /** @see #getRequiredDataGroupsOneOfSet */
-    public void setRequiredDataGroupsOneOfSet(Set<String> requiredDataGroupsOneOfSet) {
-        this.requiredDataGroupsOneOfSet = requiredDataGroupsOneOfSet != null ?
-                ImmutableSet.copyOf(requiredDataGroupsOneOfSet) : ImmutableSet.of();
     }
 
     /** Set of subpopulations that the participant must be consented to in order to receive notifications. */

--- a/src/test/java/org/sagebionetworks/bridge/notification/helper/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/helper/DynamoHelperTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
+import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -72,18 +73,15 @@ public class DynamoHelperTest {
     @Test
     public void getNotificationConfigForStudy() {
         // Set up dummy maps
-        Map<String, String> missedCumulativeMessagesMap = ImmutableMap.of(
-                "required-group-1", "cumulative-message-1",
-                "required-group-2", "cumulative-message-2");
-        Map<String, String> missedEarlyMessagesMap = ImmutableMap.of(
-                "required-group-1", "early-message-1",
-                "required-group-2", "early-message-2");
-        Map<String, String> missedLaterMessagesMap = ImmutableMap.of(
-                "required-group-1", "later-message-1",
-                "required-group-2", "later-message-2");
-        Map<String, String> preburstMessagesMap = ImmutableMap.of(
-                "required-group-1", "preburst-message-1",
-                "required-group-2", "preburst-message-2");
+        List<String> missedCumulativeMessagesList = ImmutableList.of("cumulative-message-0", "cumulative-message-1",
+                "cumulative-message-2");
+        List<String> missedEarlyMessagesList = ImmutableList.of("early-message-0", "early-message-1",
+                "early-message-2");
+        List<String> missedLaterMessagesList = ImmutableList.of("later-message-0", "later-message-1",
+                "later-message-2");
+        Map<String, List<String>> preburstMessagesMap = ImmutableMap.of(
+                "required-group-1", ImmutableList.of("preburst-message-1a", "preburst-message-1b"),
+                "required-group-2", ImmutableList.of("preburst-message-2a", "preburst-message-2b"));
 
         // Set up mock
         Item item = new Item()
@@ -93,16 +91,15 @@ public class DynamoHelperTest {
                 .withString(DynamoHelper.KEY_BURST_TASK_ID, "study-burst-task")
                 .withInt(DynamoHelper.KEY_EARLY_LATE_CUTOFF_DAYS, 7)
                 .withStringSet(DynamoHelper.KEY_EXCLUDED_DATA_GROUP_SET, "excluded-group-1", "excluded-group-2")
-                .withMap(DynamoHelper.KEY_MISSED_CUMULATIVE_MESSAGES, missedCumulativeMessagesMap)
-                .withMap(DynamoHelper.KEY_MISSED_EARLY_MESSAGES, missedEarlyMessagesMap)
-                .withMap(DynamoHelper.KEY_MISSED_LATER_MESSAGES, missedLaterMessagesMap)
+                .withList(DynamoHelper.KEY_MISSED_CUMULATIVE_MESSAGES, missedCumulativeMessagesList)
+                .withList(DynamoHelper.KEY_MISSED_EARLY_MESSAGES, missedEarlyMessagesList)
+                .withList(DynamoHelper.KEY_MISSED_LATER_MESSAGES, missedLaterMessagesList)
                 .withInt(DynamoHelper.KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_START, 2)
                 .withInt(DynamoHelper.KEY_NOTIFICATION_BLACKOUT_DAYS_FROM_END, 1)
                 .withInt(DynamoHelper.KEY_NUM_ACTIVITIES_TO_COMPLETE, 6)
                 .withInt(DynamoHelper.KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY, 3)
                 .withInt(DynamoHelper.KEY_NUM_MISSED_DAYS_TO_NOTIFY, 4)
                 .withMap(DynamoHelper.KEY_PREBURST_MESSAGES, preburstMessagesMap)
-                .withStringSet(DynamoHelper.KEY_REQUIRED_DATA_GROUPS, "required-group-1", "required-group-2")
                 .withStringSet(DynamoHelper.KEY_REQUIRED_SUBPOPULATION_GUID_SET, STUDY_ID);
         when(mockNotificationConfigTable.getItem(DynamoHelper.KEY_STUDY_ID, STUDY_ID)).thenReturn(item);
 
@@ -115,17 +112,15 @@ public class DynamoHelperTest {
         assertEquals(config.getEarlyLateCutoffDays(), 7);
         assertEquals(config.getExcludedDataGroupSet(), ImmutableSet.of("excluded-group-1",
                 "excluded-group-2"));
-        assertEquals(config.getMissedCumulativeActivitiesMessagesByDataGroup(), missedCumulativeMessagesMap);
-        assertEquals(config.getMissedEarlyActivitiesMessagesByDataGroup(), missedEarlyMessagesMap);
-        assertEquals(config.getMissedLaterActivitiesMessagesByDataGroup(), missedLaterMessagesMap);
+        assertEquals(config.getMissedCumulativeActivitiesMessagesList(), missedCumulativeMessagesList);
+        assertEquals(config.getMissedEarlyActivitiesMessagesList(), missedEarlyMessagesList);
+        assertEquals(config.getMissedLaterActivitiesMessagesList(), missedLaterMessagesList);
         assertEquals(config.getNotificationBlackoutDaysFromStart(), 2);
         assertEquals(config.getNotificationBlackoutDaysFromEnd(), 1);
         assertEquals(config.getNumActivitiesToCompleteBurst(), 6);
         assertEquals(config.getNumMissedConsecutiveDaysToNotify(), 3);
         assertEquals(config.getNumMissedDaysToNotify(), 4);
         assertEquals(config.getPreburstMessagesByDataGroup(), preburstMessagesMap);
-        assertEquals(config.getRequiredDataGroupsOneOfSet(), ImmutableSet.of("required-group-1",
-                "required-group-2"));
         assertEquals(config.getRequiredSubpopulationGuidSet(), ImmutableSet.of(STUDY_ID));
 
         verify(mockNotificationConfigTable).getItem(DynamoHelper.KEY_STUDY_ID, STUDY_ID);

--- a/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
@@ -342,8 +342,8 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
                 PREBURST_GROUP_1));
 
         // Technically, the notification worker will never process a user _before_ they're enrolled. But for the
-        // purposes of this test, this represents sending the pre-burst notification a day before the start of burst.
-        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.minusDays(1), ACCOUNT_SUMMARY);
+        // purposes of this test, this represents sending the pre-burst notification the day of the start of burst.
+        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE, ACCOUNT_SUMMARY);
         verifySentNotification(NotificationType.PRE_BURST, MESSAGE_PRE_BURST_1);
     }
 
@@ -354,7 +354,7 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
                 PREBURST_GROUP_2));
 
         // Execute test.
-        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.minusDays(1), ACCOUNT_SUMMARY);
+        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE, ACCOUNT_SUMMARY);
         verifySentNotification(NotificationType.PRE_BURST, MESSAGE_PRE_BURST_2);
     }
 
@@ -363,7 +363,7 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
         // Mock preburst notification in the log.
         UserNotification userNotification = new UserNotification();
         userNotification.setMessage(MESSAGE_PRE_BURST_1);
-        userNotification.setTime(ENROLLMENT_TIME.minusDays(1).getMillis());
+        userNotification.setTime(ENROLLMENT_TIME.getMillis());
         userNotification.setType(NotificationType.PRE_BURST);
         userNotification.setUserId(USER_ID);
         when(mockDynamoHelper.getLastNotificationTimeForUser(USER_ID)).thenReturn(userNotification);

--- a/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
@@ -342,8 +342,8 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
                 PREBURST_GROUP_1));
 
         // Technically, the notification worker will never process a user _before_ they're enrolled. But for the
-        // purposes of this test, this represents sending the pre-burst notification the day of the start of burst.
-        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE, ACCOUNT_SUMMARY);
+        // purposes of this test, this represents sending the pre-burst notification a day before the start of burst.
+        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.minusDays(1), ACCOUNT_SUMMARY);
         verifySentNotification(NotificationType.PRE_BURST, MESSAGE_PRE_BURST_1);
     }
 
@@ -354,7 +354,7 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
                 PREBURST_GROUP_2));
 
         // Execute test.
-        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE, ACCOUNT_SUMMARY);
+        processor.processAccountForDate(STUDY_ID, ENROLLMENT_DATE.minusDays(1), ACCOUNT_SUMMARY);
         verifySentNotification(NotificationType.PRE_BURST, MESSAGE_PRE_BURST_2);
     }
 
@@ -363,7 +363,7 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
         // Mock preburst notification in the log.
         UserNotification userNotification = new UserNotification();
         userNotification.setMessage(MESSAGE_PRE_BURST_1);
-        userNotification.setTime(ENROLLMENT_TIME.getMillis());
+        userNotification.setTime(ENROLLMENT_TIME.minusDays(1).getMillis());
         userNotification.setType(NotificationType.PRE_BURST);
         userNotification.setUserId(USER_ID);
         when(mockDynamoHelper.getLastNotificationTimeForUser(USER_ID)).thenReturn(userNotification);

--- a/src/test/java/org/sagebionetworks/bridge/notification/worker/WorkerConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/worker/WorkerConfigTest.java
@@ -3,17 +3,21 @@ package org.sagebionetworks.bridge.notification.worker;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 public class WorkerConfigTest {
-    private static final Map<String, String> DUMMY_MAP = ImmutableMap.of("dummy key", "dummy value");
+    private static final List<String> DUMMY_LIST = ImmutableList.of("dummy string");
+    private static final Map<String, List<String>> DUMMY_MAP = ImmutableMap.of("dummy key", ImmutableList.of(
+            "dummy value"));
     private static final Set<String> DUMMY_SET = ImmutableSet.of("dummy string");
 
     @Test
@@ -27,21 +31,21 @@ public class WorkerConfigTest {
     }
 
     @Test
-    public void missedCumulativeActivitiesMessagesByDataGroupNeverNull() {
-        testMapNeverNull(WorkerConfig::getMissedCumulativeActivitiesMessagesByDataGroup,
-                WorkerConfig::setMissedCumulativeActivitiesMessagesByDataGroup);
+    public void missedCumulativeActivitiesMessagesListNeverNull() {
+        testListNeverNull(WorkerConfig::getMissedCumulativeActivitiesMessagesList,
+                WorkerConfig::setMissedCumulativeActivitiesMessagesList);
     }
 
     @Test
-    public void missedEarlyActivitiesMessagesByDataGroupNeverNull() {
-        testMapNeverNull(WorkerConfig::getMissedEarlyActivitiesMessagesByDataGroup,
-                WorkerConfig::setMissedEarlyActivitiesMessagesByDataGroup);
+    public void missedEarlyActivitiesMessagesListNeverNull() {
+        testListNeverNull(WorkerConfig::getMissedEarlyActivitiesMessagesList,
+                WorkerConfig::setMissedEarlyActivitiesMessagesList);
     }
 
     @Test
-    public void missedLaterActivitiesMessagesByDataGroupNeverNull() {
-        testMapNeverNull(WorkerConfig::getMissedLaterActivitiesMessagesByDataGroup,
-                WorkerConfig::setMissedLaterActivitiesMessagesByDataGroup);
+    public void missedLaterActivitiesMessagesListNeverNull() {
+        testListNeverNull(WorkerConfig::getMissedLaterActivitiesMessagesList,
+                WorkerConfig::setMissedLaterActivitiesMessagesList);
     }
 
     @Test
@@ -50,14 +54,12 @@ public class WorkerConfigTest {
     }
 
     @Test
-    public void requiredDataGroupsOneOfSetNeverNull() {
-        testSetNeverNull(WorkerConfig::getRequiredDataGroupsOneOfSet, WorkerConfig::setRequiredDataGroupsOneOfSet);
-    }
-
-    @Test
     public void requiredSubpopulationGuidSetNeverNull() {
         testSetNeverNull(WorkerConfig::getRequiredSubpopulationGuidSet, WorkerConfig::setRequiredSubpopulationGuidSet);
     }
+
+    // The following tests are duplicated per collection type, because generics and inheritance behaves in ways that
+    // make this difficult to genericize.
 
     private static void testSetNeverNull(Function<WorkerConfig, Set<String>> getter,
             BiConsumer<WorkerConfig, Set<String>> setter) {
@@ -74,9 +76,24 @@ public class WorkerConfigTest {
         assertTrue(getter.apply(config).isEmpty());
     }
 
+    private static void testListNeverNull(Function<WorkerConfig, List<String>> getter,
+            BiConsumer<WorkerConfig, List<String>> setter) {
+        // Initially empty
+        WorkerConfig config = new WorkerConfig();
+        assertTrue(getter.apply(config).isEmpty());
+
+        // Set works
+        setter.accept(config, DUMMY_LIST);
+        assertEquals(getter.apply(config), DUMMY_LIST);
+
+        // Set to null gives us an empty set
+        setter.accept(config, null);
+        assertTrue(getter.apply(config).isEmpty());
+    }
+
     // Set and Map don't have a shared parent class, so sadly, we'll need to duplicate the test twice.
-    private static void testMapNeverNull(Function<WorkerConfig, Map<String, String>> getter,
-            BiConsumer<WorkerConfig, Map<String, String>> setter) {
+    private static void testMapNeverNull(Function<WorkerConfig, Map<String, List<String>>> getter,
+            BiConsumer<WorkerConfig, Map<String, List<String>>> setter) {
         // Initially empty
         WorkerConfig config = new WorkerConfig();
         assertTrue(getter.apply(config).isEmpty());


### PR DESCRIPTION
JIRAs:
* https://sagebionetworks.jira.com/browse/BRIDGE-2173 - Notification Worker should randomize from a list of messages
* https://sagebionetworks.jira.com/browse/BRIDGE-2235 - Missed Activities notification should not depend on data groups
* ~~https://sagebionetworks.jira.com/browse/BRIDGE-2256 - Pre-burst SMS notification should be on the first day of the burst~~