### PR TITLE
reduce concurrent threads from 4 to 3

### DIFF
--- a/src/main/resources/BridgeWorkerPlatform.conf
+++ b/src/main/resources/BridgeWorkerPlatform.conf
@@ -17,9 +17,9 @@ synapse.rate.limit.per.second = 10
 synapse.get.column.models.rate.limit.per.minute = 12
 workerPlatform.request.sqs.sleep.time.millis=125
 
-# As per Synapse team, there are only 4 Synapse workers for running Table queries. As such, there's no point in having
-# more than 4 thread pool workers.
-threadpool.aux.count = 4
+# You're only allowed 3 concurrent Synapse connections at a time. As such, there's no point in having
+# more than 3 thread pool workers.
+threadpool.aux.count = 3
 
 dev.synapse.map.table = dev-exporter-SynapseTables
 uat.synapse.map.table = uat-exporter-SynapseTables


### PR DESCRIPTION
Synapse only allows 3 concurrent request, so reduce thread pool from 4 to 3.