### PR TITLE
Notification Worker use Participant.isConstented instead of required subpops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.15.15</version>
+            <version>0.16.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/fitbit/bridge/FitBitUserIterator.java
+++ b/src/main/java/org/sagebionetworks/bridge/fitbit/bridge/FitBitUserIterator.java
@@ -71,7 +71,7 @@ public class FitBitUserIterator implements Iterator<FitBitUser> {
 
     // Helper method to determine if there is a next page.
     private boolean hasNextPage() {
-        return healthCodeList.getHasNext();
+        return healthCodeList.isHasNext();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/sagebionetworks/bridge/notification/helper/ActivityHistoryIterator.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/helper/ActivityHistoryIterator.java
@@ -78,7 +78,7 @@ public abstract class ActivityHistoryIterator implements Iterator<ScheduledActiv
 
     // Helper method to determine if there is a next page.
     private boolean hasNextPage() {
-        return activityList.getHasNext();
+        return activityList.isHasNext();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/sagebionetworks/bridge/notification/helper/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/helper/DynamoHelper.java
@@ -42,7 +42,6 @@ public class DynamoHelper {
     static final String KEY_NUM_MISSED_DAYS_TO_NOTIFY = "numMissedDaysToNotify";
     static final String KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY = "numMissedConsecutiveDaysToNotify";
     static final String KEY_PREBURST_MESSAGES = "preburstMessagesByDataGroup";
-    static final String KEY_REQUIRED_SUBPOPULATION_GUID_SET = "requiredSubpopulationGuidSet";
     static final String KEY_STUDY_ID = "studyId";
     static final String KEY_TAG = "tag";
     static final String KEY_USER_ID = "userId";
@@ -105,7 +104,6 @@ public class DynamoHelper {
         workerConfig.setNumMissedConsecutiveDaysToNotify(item.getInt(KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY));
         workerConfig.setNumMissedDaysToNotify(item.getInt(KEY_NUM_MISSED_DAYS_TO_NOTIFY));
         workerConfig.setPreburstMessagesByDataGroup(item.getMap(KEY_PREBURST_MESSAGES));
-        workerConfig.setRequiredSubpopulationGuidSet(item.getStringSet(KEY_REQUIRED_SUBPOPULATION_GUID_SET));
         return workerConfig;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/WorkerConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/WorkerConfig.java
@@ -26,7 +26,6 @@ public class WorkerConfig {
     private int numMissedConsecutiveDaysToNotify;
     private int numMissedDaysToNotify;
     private Map<String, List<String>> preburstMessagesByDataGroup = ImmutableMap.of();
-    private Set<String> requiredSubpopulationGuidSet = ImmutableSet.of();
 
     /**
      * URL that links back to the app (or to the study website, if for some reason the app is not installed).
@@ -211,16 +210,5 @@ public class WorkerConfig {
     public void setPreburstMessagesByDataGroup(Map<String, List<String>> preburstMessagesByDataGroup) {
         this.preburstMessagesByDataGroup = preburstMessagesByDataGroup != null ?
                 ImmutableMap.copyOf(preburstMessagesByDataGroup) : ImmutableMap.of();
-    }
-
-    /** Set of subpopulations that the participant must be consented to in order to receive notifications. */
-    public Set<String> getRequiredSubpopulationGuidSet() {
-        return requiredSubpopulationGuidSet;
-    }
-
-    /** @see #getRequiredSubpopulationGuidSet */
-    public void setRequiredSubpopulationGuidSet(Set<String> requiredSubpopulationGuidSet) {
-        this.requiredSubpopulationGuidSet = requiredSubpopulationGuidSet != null ?
-                ImmutableSet.copyOf(requiredSubpopulationGuidSet) : ImmutableSet.of();
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelper.java
@@ -28,9 +28,9 @@ public class BridgeHelper {
                 studyId, userId, false).execute().body();
         AccountInfo.Builder builder = new AccountInfo.Builder().withHealthCode(participant.getHealthCode())
                 .withUserId(userId);
-        if (participant.getEmail() != null && Boolean.TRUE.equals(participant.getEmailVerified())) {
+        if (participant.getEmail() != null && Boolean.TRUE.equals(participant.isEmailVerified())) {
             builder.withEmailAddress(participant.getEmail());
-        } else if (participant.getPhone() != null && Boolean.TRUE.equals(participant.getPhoneVerified())) {
+        } else if (participant.getPhone() != null && Boolean.TRUE.equals(participant.isPhoneVerified())) {
             builder.withPhone(participant.getPhone());
         } else {
             throw new PollSqsWorkerBadRequestException("User does not have validated email address or phone number.");

--- a/src/test/java/org/sagebionetworks/bridge/notification/helper/AccountSummaryIteratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/helper/AccountSummaryIteratorTest.java
@@ -10,6 +10,8 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -178,11 +180,13 @@ public class AccountSummaryIteratorTest {
         accountSummaryList.setTotal(total);
 
         // Make page elements
+        List<AccountSummary> items = new ArrayList<>();
         for (int i = 0; i < accountsInPage; i++) {
             AccountSummary accountSummary = new AccountSummary();
             accountSummary.setId(USER_ID_PREFIX + (offset + i));
-            accountSummaryList.addItemsItem(accountSummary);
+            items.add(accountSummary);
         }
+        accountSummaryList.setItems(items);
 
         // Mock Response and Call to return this.
         Response<AccountSummaryList> pageResponse = Response.success(accountSummaryList);

--- a/src/test/java/org/sagebionetworks/bridge/notification/helper/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/helper/DynamoHelperTest.java
@@ -101,8 +101,7 @@ public class DynamoHelperTest {
                 .withInt(DynamoHelper.KEY_NUM_ACTIVITIES_TO_COMPLETE, 6)
                 .withInt(DynamoHelper.KEY_NUM_MISSED_CONSECUTIVE_DAYS_TO_NOTIFY, 3)
                 .withInt(DynamoHelper.KEY_NUM_MISSED_DAYS_TO_NOTIFY, 4)
-                .withMap(DynamoHelper.KEY_PREBURST_MESSAGES, preburstMessagesMap)
-                .withStringSet(DynamoHelper.KEY_REQUIRED_SUBPOPULATION_GUID_SET, STUDY_ID);
+                .withMap(DynamoHelper.KEY_PREBURST_MESSAGES, preburstMessagesMap);
         when(mockNotificationConfigTable.getItem(DynamoHelper.KEY_STUDY_ID, STUDY_ID)).thenReturn(item);
 
         // Execute and validate
@@ -125,7 +124,6 @@ public class DynamoHelperTest {
         assertEquals(config.getNumMissedConsecutiveDaysToNotify(), 3);
         assertEquals(config.getNumMissedDaysToNotify(), 4);
         assertEquals(config.getPreburstMessagesByDataGroup(), preburstMessagesMap);
-        assertEquals(config.getRequiredSubpopulationGuidSet(), ImmutableSet.of(STUDY_ID));
 
         verify(mockNotificationConfigTable).getItem(DynamoHelper.KEY_STUDY_ID, STUDY_ID);
 

--- a/src/test/java/org/sagebionetworks/bridge/notification/helper/TaskHistoryIteratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/helper/TaskHistoryIteratorTest.java
@@ -10,6 +10,8 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.testng.annotations.BeforeMethod;
@@ -192,11 +194,13 @@ public class TaskHistoryIteratorTest {
         forwardCursorStringList.setNextPageOffsetKey(nextPageOffsetKey);
 
         // Make page elements
+        List<ScheduledActivity> scheduledActivityList = new ArrayList<>();
         for (int i = start; i <= end; i++) {
             ScheduledActivity scheduledActivity = new ScheduledActivity();
             scheduledActivity.setGuid(ACTIVITY_GUID_PREFIX + i);
-            forwardCursorStringList.addItemsItem(scheduledActivity);
+            scheduledActivityList.add(scheduledActivity);
         }
+        forwardCursorStringList.setItems(scheduledActivityList);
 
         // Mock Response and Call to return this.
         Response<ForwardCursorScheduledActivityList> pageResponse = Response.success(forwardCursorStringList);

--- a/src/test/java/org/sagebionetworks/bridge/notification/worker/WorkerConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/worker/WorkerConfigTest.java
@@ -53,11 +53,6 @@ public class WorkerConfigTest {
         testMapNeverNull(WorkerConfig::getPreburstMessagesByDataGroup, WorkerConfig::setPreburstMessagesByDataGroup);
     }
 
-    @Test
-    public void requiredSubpopulationGuidSetNeverNull() {
-        testSetNeverNull(WorkerConfig::getRequiredSubpopulationGuidSet, WorkerConfig::setRequiredSubpopulationGuidSet);
-    }
-
     // The following tests are duplicated per collection type, because generics and inheritance behaves in ways that
     // make this difficult to genericize.
 

--- a/src/test/java/org/sagebionetworks/bridge/reporter/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/reporter/helper/BridgeHelperTest.java
@@ -72,7 +72,7 @@ public class BridgeHelperTest {
     private Upload testUpload;
 
     @BeforeClass
-    public void setup() throws IOException {
+    public void setup() {
         testUpload = RestUtils.GSON.fromJson(json, Upload.class);
     }
 
@@ -249,11 +249,16 @@ public class BridgeHelperTest {
     
     private Call<AccountSummaryList> createResponseForOffset(int offsetBy, AccountSummary... summaries) throws IOException {
         List<AccountSummary> page = new ArrayList<>();
-        RequestParams requestParams = new RequestParams().offsetBy(offsetBy).pageSize(100)
-                .startTime(TEST_START_DATETIME).endTime(TEST_END_DATETIME);
+
+        RequestParams mockRequestParams = mock(RequestParams.class);
+        when(mockRequestParams.getOffsetBy()).thenReturn(offsetBy);
+        when(mockRequestParams.getPageSize()).thenReturn(100);
+        when(mockRequestParams.getStartTime()).thenReturn(TEST_START_DATETIME);
+        when(mockRequestParams.getEndTime()).thenReturn(TEST_END_DATETIME);
+
         AccountSummaryList list = new AccountSummaryList();
         list.setItems(page);
-        list.setRequestParams(requestParams);
+        list.setRequestParams(mockRequestParams);
         list.setTotal(120);
 
         for (AccountSummary summary : summaries) {

--- a/src/test/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelperTest.java
@@ -28,7 +28,7 @@ public class BridgeHelperTest {
         // mock StudyParticipant - We can't set the healthcode, but we need to return it for test.
         StudyParticipant mockParticipant = mock(StudyParticipant.class);
         when(mockParticipant.getEmail()).thenReturn(EMAIL);
-        when(mockParticipant.getEmailVerified()).thenReturn(Boolean.TRUE);
+        when(mockParticipant.isEmailVerified()).thenReturn(Boolean.TRUE);
         when(mockParticipant.getHealthCode()).thenReturn(HEALTH_CODE);
 
         // mock bridge calls
@@ -57,9 +57,9 @@ public class BridgeHelperTest {
         // mock StudyParticipant - We can't set the healthcode, but we need to return it for test.
         StudyParticipant mockParticipant = mock(StudyParticipant.class);
         when(mockParticipant.getEmail()).thenReturn(EMAIL);
-        when(mockParticipant.getEmailVerified()).thenReturn(Boolean.FALSE);
+        when(mockParticipant.isEmailVerified()).thenReturn(Boolean.FALSE);
         when(mockParticipant.getPhone()).thenReturn(PHONE);
-        when(mockParticipant.getPhoneVerified()).thenReturn(Boolean.TRUE);
+        when(mockParticipant.isPhoneVerified()).thenReturn(Boolean.TRUE);
         when(mockParticipant.getHealthCode()).thenReturn(HEALTH_CODE);
 
         // mock bridge calls
@@ -90,9 +90,9 @@ public class BridgeHelperTest {
         StudyParticipant mockParticipant = mock(StudyParticipant.class);
         // Verify that null is also acceptable (and false)
         when(mockParticipant.getEmail()).thenReturn(null);
-        when(mockParticipant.getEmailVerified()).thenReturn(null);
+        when(mockParticipant.isEmailVerified()).thenReturn(null);
         when(mockParticipant.getPhone()).thenReturn(PHONE);
-        when(mockParticipant.getPhoneVerified()).thenReturn(null);
+        when(mockParticipant.isPhoneVerified()).thenReturn(null);
         when(mockParticipant.getHealthCode()).thenReturn(HEALTH_CODE);
 
         // mock bridge calls


### PR DESCRIPTION
Notification Worker assumed that we'd have required subpops that people would be submitting consents to. As it turns out, clinical consents don't require eConsent. This change merely checks that the user is consented, based on the new StudyParticipant.isConsented flag.

This change requires https://github.com/Sage-Bionetworks/BridgePF/pull/1763