### PR TITLE
Upload Redrive Worker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.16.3</version>
+            <version>0.16.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/notification/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/config/SpringConfig.java
@@ -25,11 +25,4 @@ public class SpringConfig {
         String fullyQualifiedTableName = namingHelper.getFullyQualifiedTableName("NotificationLog");
         return ddbClient.getTable(fullyQualifiedTableName);
     }
-
-    @Bean(name = "ddbWorkerLogTable")
-    @Autowired
-    public Table ddbWorkerLogTable(DynamoDB ddbClient, DynamoNamingHelper namingHelper) {
-        String fullyQualifiedTableName = namingHelper.getFullyQualifiedTableName("WorkerLog");
-        return ddbClient.getTable(fullyQualifiedTableName);
-    }
 }

--- a/src/main/java/org/sagebionetworks/bridge/uploadredrive/RedriveType.java
+++ b/src/main/java/org/sagebionetworks/bridge/uploadredrive/RedriveType.java
@@ -1,0 +1,7 @@
+package org.sagebionetworks.bridge.uploadredrive;
+
+/** Enum determines whether the redrive job is a list of upload IDs or record IDs. */
+public enum RedriveType {
+    UPLOAD_ID,
+    RECORD_ID,
+}

--- a/src/main/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessor.java
@@ -94,7 +94,7 @@ public class UploadRedriveWorkerProcessor implements ThrowingConsumer<JsonNode> 
         }
         RedriveType redriveType;
         try {
-            redriveType = RedriveType.valueOf(redriveTypeStr);
+            redriveType = RedriveType.valueOf(redriveTypeStr.toUpperCase());
         } catch (IllegalArgumentException ex) {
             throw new PollSqsWorkerBadRequestException("invalid redrive type: " + redriveTypeStr);
         }

--- a/src/main/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessor.java
@@ -1,0 +1,169 @@
+package org.sagebionetworks.bridge.uploadredrive;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Joiner;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.TreeMultiset;
+import com.google.common.util.concurrent.RateLimiter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.rest.model.Upload;
+import org.sagebionetworks.bridge.rest.model.UploadStatus;
+import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
+import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.sqs.PollSqsWorkerBadRequestException;
+import org.sagebionetworks.bridge.worker.ThrowingConsumer;
+import org.sagebionetworks.bridge.workerPlatform.helper.BridgeHelper;
+import org.sagebionetworks.bridge.workerPlatform.helper.DynamoHelper;
+import org.sagebionetworks.bridge.workerPlatform.util.JsonUtils;
+
+/** Worker used to redrive uploads. Takes in a list of upload IDs or a list of record IDs. */
+@Component("UploadRedriveWorker")
+public class UploadRedriveWorkerProcessor implements ThrowingConsumer<JsonNode> {
+    private static final Logger LOG = LoggerFactory.getLogger(UploadRedriveWorkerProcessor.class);
+
+    private static final Joiner COMMA_SPACE_JOINER = Joiner.on(", ").skipNulls();
+    static final String WORKER_ID = "UploadRedriveWorker";
+
+    // If there are a lot of uploads, write log messages regularly so we know the worker is still running.
+    private static final int REPORTING_INTERVAL = 100;
+
+    static final String REQUEST_PARAM_S3_BUCKET = "s3Bucket";
+    static final String REQUEST_PARAM_S3_KEY = "s3Key";
+    static final String REQUEST_PARAM_REDRIVE_TYPE = "redriveType";
+
+    private final RateLimiter perUploadRateLimiter = RateLimiter.create(1.0);
+
+    private BridgeHelper bridgeHelper;
+    private DynamoHelper dynamoHelper;
+    private S3Helper s3Helper;
+
+    /** Helps call Bridge Server APIs. */
+    @Autowired
+    public final void setBridgeHelper(BridgeHelper bridgeHelper) {
+        this.bridgeHelper = bridgeHelper;
+    }
+
+    /** Mainly used to write the worker log. */
+    @Autowired
+    public final void setDynamoHelper(DynamoHelper dynamoHelper) {
+        this.dynamoHelper = dynamoHelper;
+    }
+
+    /**
+     * Set rate limit, in upload per second. This is primarily to allow unit tests to run without being throttled. Note
+     * that in production, since we're running in synchronous mode (to allow better robustness), it's possible that
+     * this will run slower than the rate limit.
+     */
+    // TODO: Invest in making this both multi-threaded and robust.
+    public final void setPerUploadRateLimit(double rate) {
+        perUploadRateLimiter.setRate(rate);
+    }
+
+    /** S3 Helper, used to download list of IDs from S3. */
+    @Autowired
+    public final void setS3Helper(S3Helper s3Helper) {
+        this.s3Helper = s3Helper;
+    }
+
+    /** Main entry point into the Redrive Worker. */
+    @Override
+    public void accept(JsonNode jsonNode) throws IOException, PollSqsWorkerBadRequestException {
+        // Request args is just an s3 bucket and key.
+        String s3Bucket = JsonUtils.asText(jsonNode, REQUEST_PARAM_S3_BUCKET);
+        if (s3Bucket == null) {
+            throw new PollSqsWorkerBadRequestException("s3Bucket must be specified");
+        }
+
+        String s3Key = JsonUtils.asText(jsonNode, REQUEST_PARAM_S3_KEY);
+        if (s3Key == null) {
+            throw new PollSqsWorkerBadRequestException("s3Key must be specified");
+        }
+
+        String redriveTypeStr = JsonUtils.asText(jsonNode, REQUEST_PARAM_REDRIVE_TYPE);
+        if (redriveTypeStr == null) {
+            throw new PollSqsWorkerBadRequestException("redriveType must be specified");
+        }
+        RedriveType redriveType;
+        try {
+            redriveType = RedriveType.valueOf(redriveTypeStr);
+        } catch (IllegalArgumentException ex) {
+            throw new PollSqsWorkerBadRequestException("invalid redrive type: " + redriveTypeStr);
+        }
+
+        // Download file from S3. We expect each line to be its own upload/record ID.
+        List<String> sourceIdList = s3Helper.readS3FileAsLines(s3Bucket, s3Key);
+
+        LOG.info("Received redrive request with params s3Bucket=" + s3Bucket + ", s3Key=" + s3Key + ", redriveType=" +
+                redriveTypeStr);
+
+        int numUploads = 0;
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        Multiset<String> metrics = TreeMultiset.create();
+        for (String id : sourceIdList) {
+            // Rate limit.
+            perUploadRateLimiter.acquire();
+
+            // Process.
+            try {
+                processId(id, redriveType, metrics);
+            } catch (Exception ex) {
+                LOG.error("Error processing id " + id + ": " + ex.getMessage(), ex);
+                metrics.add("error");
+            }
+
+            // Reporting.
+            numUploads++;
+            if (numUploads % REPORTING_INTERVAL == 0) {
+                LOG.info("Processing uploads in progress: " + numUploads + " uploads in " +
+                        stopwatch.elapsed(TimeUnit.SECONDS) + " seconds");
+            }
+        }
+
+        // Write to Worker Log in DDB so we can signal end of processing.
+        String tag = "s3Bucket=" + s3Bucket + ", s3Key=" + s3Key + ", redriveType=" + redriveTypeStr;
+        dynamoHelper.writeWorkerLog(WORKER_ID, tag);
+
+        LOG.info("Finished processing uploads: " + numUploads + " uploads in " + stopwatch.elapsed(TimeUnit.SECONDS) +
+                " seconds");
+
+        logMetrics(metrics);
+    }
+
+    // Helper method to process a single upload. Package-scoped to facilitate unit tests.
+    void processId(String id, RedriveType redriveType, Multiset<String> metrics) throws IOException {
+        String uploadId;
+        if (redriveType == RedriveType.RECORD_ID) {
+            // We have record IDs. Fetch the upload so we can have upload IDs.
+            Upload upload = bridgeHelper.getUploadByRecordId(id);
+            uploadId = upload.getUploadId();
+        } else {
+            // This is trivial.
+            uploadId = id;
+        }
+
+        // Call the upload complete API again. redrive=true to allow us to redrive uploads that are already complete.
+        // synchronous=true so we can have better logging for failed uploads.
+        UploadValidationStatus status = bridgeHelper.completeUploadSession(uploadId, true, true);
+        metrics.add(status.getStatus().getValue());
+        if (status.getStatus() != UploadStatus.SUCCEEDED) {
+            LOG.error("Redrive failed for id=" + id + ", uploadId=" + uploadId + ": " + COMMA_SPACE_JOINER.join(
+                    status.getMessageList()));
+        }
+    }
+
+    // Helper method to log metrics. Package-scoped to allow unit tests to intercept metrics as they are logged.
+    void logMetrics(Multiset<String> metrics) {
+        for (Multiset.Entry<String> metricEntry : metrics.entrySet()) {
+            LOG.info(metricEntry.getElement() + "=" + metricEntry.getCount());
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
@@ -45,7 +45,10 @@ import org.sagebionetworks.bridge.workerPlatform.multiplexer.Constants;
 // For EC2 instances, this happens transparently.
 // See http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html and
 // http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-setup.html#set-up-creds for more info.
-@ComponentScan("org.sagebionetworks.bridge.workerPlatform")
+@ComponentScan({
+        "org.sagebionetworks.bridge.uploadredrive",
+        "org.sagebionetworks.bridge.workerPlatform",
+})
 @Import({
         org.sagebionetworks.bridge.fitbit.config.SpringConfig.class,
         org.sagebionetworks.bridge.notification.config.SpringConfig.class,
@@ -133,6 +136,12 @@ public class SpringConfig {
     @Bean(name = "ddbUploadSchemaStudyIndex")
     public Index ddbUploadSchemaStudyIndex() {
         return ddbUploadSchemaTable(bridgeConfig()).getIndex("studyId-index");
+    }
+
+    @Bean(name = "ddbWorkerLogTable")
+    public Table ddbWorkerLogTable() {
+        String fullyQualifiedTableName = dynamoNamingHelper().getFullyQualifiedTableName("WorkerLog");
+        return ddbClient().getTable(fullyQualifiedTableName);
     }
 
     @Bean

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelper.java
@@ -1,0 +1,36 @@
+package org.sagebionetworks.bridge.workerPlatform.helper;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.model.Upload;
+import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
+
+/** Abstracts away calls to Bridge. */
+// TODO consolidate all the other BridgeHelpers into this one
+@Component("BridgeHelper")
+public class BridgeHelper {
+    private ClientManager clientManager;
+
+    /** Bridge client manager. */
+    @Autowired
+    public final void setClientManager(ClientManager clientManager) {
+        this.clientManager = clientManager;
+    }
+
+    /** Completes an upload session, with the optional synchronous and redrive flags. */
+    public UploadValidationStatus completeUploadSession(String uploadId, Boolean synchronous, Boolean redrive)
+            throws IOException {
+        return clientManager.getClient(ForWorkersApi.class).completeUploadSession(uploadId, synchronous, redrive)
+                .execute().body();
+    }
+
+    /** Gets an upload by record ID. */
+    public Upload getUploadByRecordId(String recordId) throws IOException {
+        return clientManager.getClient(ForWorkersApi.class).getUploadByRecordId(recordId).execute().body();
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/DynamoHelper.java
@@ -1,0 +1,35 @@
+package org.sagebionetworks.bridge.workerPlatform.helper;
+
+import javax.annotation.Resource;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import org.joda.time.DateTime;
+import org.springframework.stereotype.Component;
+
+/** Abstracts away calls to DynamoDB. */
+// TODO consolidate all the other BridgeHelpers into this one
+@Component("DynamoHelper")
+public class DynamoHelper {
+    static final String KEY_FINISH_TIME = "finishTime";
+    static final String KEY_TAG = "tag";
+    static final String KEY_WORKER_ID = "workerId";
+
+    private Table ddbWorkerLogTable;
+
+    /**
+     * DDB table for the worker log. Used to track worker runs and to signal to integration tests when the worker has
+     * finished running.
+     */
+    @Resource(name = "ddbWorkerLogTable")
+    public final void setDdbWorkerLogTable(Table ddbWorkerLogTable) {
+        this.ddbWorkerLogTable = ddbWorkerLogTable;
+    }
+
+    /** Writes the worker run to the worker log, with the current timestamp and the given tag. */
+    public void writeWorkerLog(String workerId, String tag) {
+        Item item = new Item().withPrimaryKey(KEY_WORKER_ID, workerId, KEY_FINISH_TIME,
+                DateTime.now().getMillis()).withString(KEY_TAG, tag);
+        ddbWorkerLogTable.putItem(item);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/util/JsonUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/util/JsonUtils.java
@@ -1,0 +1,25 @@
+package org.sagebionetworks.bridge.workerPlatform.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
+
+/** JSON utility methods. */
+public class JsonUtils {
+    /**
+     * Gets a value from a parent node as a string. If the value does not exist or is not a string or is a blank
+     * string, this returns null.
+     */
+    public static String asText(JsonNode parent, String property) {
+        if (parent != null && parent.hasNonNull(property)) {
+            JsonNode child = parent.get(property);
+            if (child.isTextual()) {
+                String value = child.textValue();
+                if (StringUtils.isNotBlank(value)) {
+                    return value;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorProcessIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorProcessIdTest.java
@@ -1,0 +1,71 @@
+package org.sagebionetworks.bridge.uploadredrive;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.Multiset;
+import com.google.common.collect.TreeMultiset;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.rest.model.Upload;
+import org.sagebionetworks.bridge.rest.model.UploadStatus;
+import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
+import org.sagebionetworks.bridge.workerPlatform.helper.BridgeHelper;
+
+public class UploadRedriveWorkerProcessorProcessIdTest {
+    private static final String RECORD_ID = "my-record";
+    private static final String UPLOAD_ID = "my-upload";
+
+    private BridgeHelper mockBridgeHelper;
+    private UploadRedriveWorkerProcessor processor;
+
+    @BeforeMethod
+    public void before() {
+        mockBridgeHelper = mock(BridgeHelper.class);
+
+        processor = new UploadRedriveWorkerProcessor();
+        processor.setBridgeHelper(mockBridgeHelper);
+    }
+
+    @Test
+    public void byUploadId() throws Exception {
+        // Mock Bridge Helper.
+        UploadValidationStatus status = new UploadValidationStatus().status(UploadStatus.SUCCEEDED);
+        when(mockBridgeHelper.completeUploadSession(UPLOAD_ID, true, true)).thenReturn(status);
+
+        // Execute.
+        Multiset<String> metrics = TreeMultiset.create();
+        processor.processId(UPLOAD_ID, RedriveType.UPLOAD_ID, metrics);
+
+        // Verify bridge call.
+        verify(mockBridgeHelper).completeUploadSession(UPLOAD_ID, true, true);
+
+        // Verify metrics.
+        assertEquals(metrics.size(), 1);
+        assertEquals(metrics.count(UploadStatus.SUCCEEDED.getValue()), 1);
+    }
+
+    @Test
+    public void byRecordId() throws Exception {
+        // Mock Bridge Helper.
+        Upload upload = new Upload().uploadId(UPLOAD_ID);
+        when(mockBridgeHelper.getUploadByRecordId(RECORD_ID)).thenReturn(upload);
+
+        UploadValidationStatus status = new UploadValidationStatus().status(UploadStatus.VALIDATION_FAILED);
+        when(mockBridgeHelper.completeUploadSession(UPLOAD_ID, true, true)).thenReturn(status);
+
+        // Execute.
+        Multiset<String> metrics = TreeMultiset.create();
+        processor.processId(RECORD_ID, RedriveType.RECORD_ID, metrics);
+
+        // Verify bridge call.
+        verify(mockBridgeHelper).completeUploadSession(UPLOAD_ID, true, true);
+
+        // Verify metrics.
+        assertEquals(metrics.size(), 1);
+        assertEquals(metrics.count(UploadStatus.VALIDATION_FAILED.getValue()), 1);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorTest.java
@@ -99,7 +99,7 @@ public class UploadRedriveWorkerProcessorTest {
 
         // Verify worker log.
         verify(mockDynamoHelper).writeWorkerLog(UploadRedriveWorkerProcessor.WORKER_ID, "s3Bucket=" + S3_BUCKET +
-                ", s3Key=" + S3_KEY + ", redriveType=" + RedriveType.UPLOAD_ID.name());
+                ", s3Key=" + S3_KEY + ", redriveType=upload_id");
 
         // Verify metrics. Most metrics are logged by processId(). The only metric logged here is "error".
         ArgumentCaptor<Multiset> metricsCaptor = ArgumentCaptor.forClass(Multiset.class);
@@ -114,7 +114,10 @@ public class UploadRedriveWorkerProcessorTest {
         ObjectNode requestNode = JSON_MAPPER.createObjectNode();
         requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_S3_BUCKET, S3_BUCKET);
         requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_S3_KEY, S3_KEY);
-        requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_REDRIVE_TYPE, RedriveType.UPLOAD_ID.name());
+
+        // Use lower-case to verify case insensitivity.
+        requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_REDRIVE_TYPE, "upload_id");
+
         return requestNode;
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorTest.java
@@ -1,0 +1,120 @@
+package org.sagebionetworks.bridge.uploadredrive;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multiset;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.sqs.PollSqsWorkerBadRequestException;
+import org.sagebionetworks.bridge.workerPlatform.helper.DynamoHelper;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class UploadRedriveWorkerProcessorTest {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final String S3_BUCKET = "my-bucket";
+    private static final String S3_KEY = "my-key";
+
+    private DynamoHelper mockDynamoHelper;
+    private S3Helper mockS3Helper;
+    private UploadRedriveWorkerProcessor processor;
+
+    @BeforeMethod
+    public void before() throws Exception {
+        // Set up mocks
+        mockDynamoHelper = mock(DynamoHelper.class);
+        mockS3Helper = mock(S3Helper.class);
+
+        // Create processor. Spy the processor so we can test processId() in a separate set of tests.
+        processor = spy(new UploadRedriveWorkerProcessor());
+        processor.setDynamoHelper(mockDynamoHelper);
+        processor.setS3Helper(mockS3Helper);
+        processor.setPerUploadRateLimit(1000.0);
+
+        doNothing().when(processor).processId(any(), any(), any());
+    }
+
+    @Test(expectedExceptions = PollSqsWorkerBadRequestException.class, expectedExceptionsMessageRegExp =
+            "s3Bucket must be specified")
+    public void noS3Bucket() throws Exception {
+        ObjectNode requestNode = makeValidRequestNode();
+        requestNode.remove(UploadRedriveWorkerProcessor.REQUEST_PARAM_S3_BUCKET);
+        processor.accept(requestNode);
+    }
+
+    @Test(expectedExceptions = PollSqsWorkerBadRequestException.class, expectedExceptionsMessageRegExp =
+            "s3Key must be specified")
+    public void noS3Key() throws Exception {
+        ObjectNode requestNode = makeValidRequestNode();
+        requestNode.remove(UploadRedriveWorkerProcessor.REQUEST_PARAM_S3_KEY);
+        processor.accept(requestNode);
+    }
+
+    @Test(expectedExceptions = PollSqsWorkerBadRequestException.class, expectedExceptionsMessageRegExp =
+            "redriveType must be specified")
+    public void noRedrieveType() throws Exception {
+        ObjectNode requestNode = makeValidRequestNode();
+        requestNode.remove(UploadRedriveWorkerProcessor.REQUEST_PARAM_REDRIVE_TYPE);
+        processor.accept(requestNode);
+    }
+
+    @Test(expectedExceptions = PollSqsWorkerBadRequestException.class, expectedExceptionsMessageRegExp =
+            "invalid redrive type: foo")
+    public void invalidRedriveType() throws Exception {
+        ObjectNode requestNode = makeValidRequestNode();
+        requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_REDRIVE_TYPE, "foo");
+        processor.accept(requestNode);
+    }
+
+    @Test
+    public void normalCase() throws Exception {
+        // Mock S3 Helper.
+        when(mockS3Helper.readS3FileAsLines(S3_BUCKET, S3_KEY)).thenReturn(ImmutableList.of("upload-1", "upload-2",
+                "upload-3"));
+
+        // Upload 2 throws.
+        doThrow(RuntimeException.class).when(processor).processId(eq("upload-2"), eq(RedriveType.UPLOAD_ID),
+                any());
+
+        // Execute.
+        processor.accept(makeValidRequestNode());
+
+        // Verify 3 calls to processId().
+        verify(processor).processId(eq("upload-1"), eq(RedriveType.UPLOAD_ID), any());
+        verify(processor).processId(eq("upload-2"), eq(RedriveType.UPLOAD_ID), any());
+        verify(processor).processId(eq("upload-3"), eq(RedriveType.UPLOAD_ID), any());
+
+        // Verify worker log.
+        verify(mockDynamoHelper).writeWorkerLog(UploadRedriveWorkerProcessor.WORKER_ID, "s3Bucket=" + S3_BUCKET +
+                ", s3Key=" + S3_KEY + ", redriveType=" + RedriveType.UPLOAD_ID.name());
+
+        // Verify metrics. Most metrics are logged by processId(). The only metric logged here is "error".
+        ArgumentCaptor<Multiset> metricsCaptor = ArgumentCaptor.forClass(Multiset.class);
+        verify(processor).logMetrics(metricsCaptor.capture());
+
+        Multiset<String> metrics = metricsCaptor.getValue();
+        assertEquals(metrics.size(), 1);
+        assertEquals(metrics.count("error"), 1);
+    }
+
+    private static ObjectNode makeValidRequestNode() {
+        ObjectNode requestNode = JSON_MAPPER.createObjectNode();
+        requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_S3_BUCKET, S3_BUCKET);
+        requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_S3_KEY, S3_KEY);
+        requestNode.put(UploadRedriveWorkerProcessor.REQUEST_PARAM_REDRIVE_TYPE, RedriveType.UPLOAD_ID.name());
+        return requestNode;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelperTest.java
@@ -1,0 +1,74 @@
+package org.sagebionetworks.bridge.workerPlatform.helper;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertSame;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.model.Upload;
+import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
+
+@SuppressWarnings("unchecked")
+public class BridgeHelperTest {
+    private static final String RECORD_ID = "dummy-record";
+    private static final String UPLOAD_ID = "dummy-upload";
+
+    private BridgeHelper bridgeHelper;
+    private ForWorkersApi mockWorkerApi;
+
+    @BeforeMethod
+    public void setup() {
+        mockWorkerApi = mock(ForWorkersApi.class);
+
+        ClientManager mockClientManager = mock(ClientManager.class);
+        when(mockClientManager.getClient(ForWorkersApi.class)).thenReturn(mockWorkerApi);
+
+        bridgeHelper = new BridgeHelper();
+        bridgeHelper.setClientManager(mockClientManager);
+    }
+
+    @Test
+    public void completeUploadSession() throws Exception {
+        // Mock API.
+        UploadValidationStatus status = new UploadValidationStatus();
+        Response<UploadValidationStatus> response = Response.success(status);
+
+        Call<UploadValidationStatus> call = mock(Call.class);
+        when(call.execute()).thenReturn(response);
+
+        when(mockWorkerApi.completeUploadSession(any(), any(), any())).thenReturn(call);
+
+        // Execute and verify.
+        UploadValidationStatus outputStatus = bridgeHelper.completeUploadSession(UPLOAD_ID, true,
+                true);
+        assertSame(outputStatus, status);
+
+        verify(mockWorkerApi).completeUploadSession(UPLOAD_ID, true, true);
+    }
+
+    @Test
+    public void getUploadByRecordId() throws Exception {
+        // Mock API.
+        Upload upload = new Upload();
+        Response<Upload> response = Response.success(upload);
+
+        Call<Upload> call = mock(Call.class);
+        when(call.execute()).thenReturn(response);
+
+        when(mockWorkerApi.getUploadByRecordId(any())).thenReturn(call);
+
+        // Execute and verify.
+        Upload outputUpload = bridgeHelper.getUploadByRecordId(RECORD_ID);
+        assertSame(outputUpload, upload);
+
+        verify(mockWorkerApi).getUploadByRecordId(RECORD_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/DynamoHelperTest.java
@@ -1,0 +1,57 @@
+package org.sagebionetworks.bridge.workerPlatform.helper;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DynamoHelperTest {
+    private static final long MOCK_NOW_MILLIS = DateTime.parse("2018-04-27T16:41:15.831-0700").getMillis();
+
+    private DynamoHelper dynamoHelper;
+    private Table mockWorkerLogTable;
+
+    @BeforeClass
+    public static void mockNow() {
+        DateTimeUtils.setCurrentMillisFixed(MOCK_NOW_MILLIS);
+    }
+
+    @AfterClass
+    public static void unmockNow() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @BeforeMethod
+    public void before() {
+        // Set up mocks
+        mockWorkerLogTable = mock(Table.class);
+
+        // Create DynamoHelper
+        dynamoHelper = new DynamoHelper();
+        dynamoHelper.setDdbWorkerLogTable(mockWorkerLogTable);
+    }
+
+    @Test
+    public void writeWorkerLog() {
+        // Execute
+        dynamoHelper.writeWorkerLog("dummy worker", "dummy tag");
+
+        // Validate back-end
+        ArgumentCaptor<Item> itemCaptor = ArgumentCaptor.forClass(Item.class);
+        verify(mockWorkerLogTable).putItem(itemCaptor.capture());
+
+        Item item = itemCaptor.getValue();
+        assertEquals(item.getString(DynamoHelper.KEY_WORKER_ID), "dummy worker");
+        assertEquals(item.getLong(DynamoHelper.KEY_FINISH_TIME), MOCK_NOW_MILLIS);
+        assertEquals(item.getString(DynamoHelper.KEY_TAG), "dummy tag");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/util/JsonUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/util/JsonUtilsTest.java
@@ -1,0 +1,40 @@
+package org.sagebionetworks.bridge.workerPlatform.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+
+public class JsonUtilsTest {
+    // branch coverage
+    @Test
+    public void asTextNullParent() {
+        assertNull(JsonUtils.asText(null, "any"));
+    }
+
+    @DataProvider(name = "asTextProvider")
+    public Object[][] asTextProvider() {
+        // { [input json text], [expected] }
+        // property="prop"
+        return new Object[][] {
+                { "null", null },
+                { "\"string\"", null },
+                { "{}", null },
+                { "{\"prop\":null}", null },
+                { "{\"prop\":42}", null },
+                { "{\"prop\":\"\"}", null },
+                { "{\"prop\":\"   \"}", null },
+                { "{\"prop\":\"value\"}", "value" },
+        };
+    }
+
+    @Test(dataProvider = "asTextProvider")
+    public void asText(String inputJsonText, String expected) throws Exception {
+        JsonNode parent = DefaultObjectMapper.INSTANCE.readTree(inputJsonText);
+        assertEquals(JsonUtils.asText(parent, "prop"), expected);
+    }
+}


### PR DESCRIPTION
A new, more robust upload redrive worker, to replace the brittle backfill controller in BridgePF.

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* wrote new integ tests