### PR TITLE
Redrive Worker - Move upload polling to client-side

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,8 +247,8 @@
                         <exclude>org/sagebionetworks/bridge/workerPlatform/multiplexer/Constants.class</exclude>
 
                         <!-- no point in testing exceptions, since they are entirely boilerplate code -->
-                        <exclude>org/sagebionetworks/bridge/reporter/exceptions/*</exclude>
                         <exclude>org/sagebionetworks/bridge/udd/exceptions/*</exclude>
+                        <exclude>org/sagebionetworks/bridge/workerPlatform/exceptions/*</exclude>
                     </excludes>
                     <rules>
                         <rule>

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/exceptions/AsyncTimeoutException.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/exceptions/AsyncTimeoutException.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.bridge.workerPlatform.exceptions;
+
+/**
+ * Thrown when an async request (such as a Bridge upload complete or Synapse download request) fails to complete before
+ * we hit our max poll limit.
+ */
+@SuppressWarnings("serial")
+public class AsyncTimeoutException extends Exception {
+    public AsyncTimeoutException() {
+    }
+
+    public AsyncTimeoutException(String message) {
+        super(message);
+    }
+
+    public AsyncTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AsyncTimeoutException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelper.java
@@ -2,19 +2,30 @@ package org.sagebionetworks.bridge.workerPlatform.helper;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.model.Upload;
+import org.sagebionetworks.bridge.rest.model.UploadStatus;
 import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
+import org.sagebionetworks.bridge.workerPlatform.exceptions.AsyncTimeoutException;
 
 /** Abstracts away calls to Bridge. */
 // TODO consolidate all the other BridgeHelpers into this one
 @Component("BridgeHelper")
 public class BridgeHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(BridgeHelper.class);
+
+    private static final long DEFAULT_POLL_TIME_MILLIS = 5000;
+    private static final int DEFAULT_POLL_MAX_ITERATIONS = 12;
+
     private ClientManager clientManager;
+    private long pollTimeMillis = DEFAULT_POLL_TIME_MILLIS;
+    private int pollMaxIterations = DEFAULT_POLL_MAX_ITERATIONS;
 
     /** Bridge client manager. */
     @Autowired
@@ -22,11 +33,52 @@ public class BridgeHelper {
         this.clientManager = clientManager;
     }
 
-    /** Completes an upload session, with the optional synchronous and redrive flags. */
-    public UploadValidationStatus completeUploadSession(String uploadId, Boolean synchronous, Boolean redrive)
-            throws IOException {
-        return clientManager.getClient(ForWorkersApi.class).completeUploadSession(uploadId, synchronous, redrive)
-                .execute().body();
+    /** Allows unit tests to override the poll time. */
+    final void setPollTimeMillis(long pollTimeMillis) {
+        this.pollTimeMillis = pollTimeMillis;
+    }
+
+    /** Allow unit tests to override the poll max iterations. */
+    final void setPollMaxIterations(int pollMaxIterations) {
+        this.pollMaxIterations = pollMaxIterations;
+    }
+
+    /**
+     * Redrives an upload synchronously. This calls the upload complete API with the redrive flag and polls until
+     * completion.
+     */
+    public UploadStatusAndMessages redriveUpload(String uploadId) throws AsyncTimeoutException, IOException {
+        // Note: We don't use the synchronous flag, because S3 download and upload can sometimes take a long time and
+        // cause the request to time out, which is an ops problem if we need to redrive thousands of uploads. Instead,
+        // call with synchronous=false and manually poll.
+        UploadValidationStatus validationStatus = clientManager.getClient(ForWorkersApi.class)
+                .completeUploadSession(uploadId, false, true).execute().body();
+        if (validationStatus.getStatus() != UploadStatus.VALIDATION_IN_PROGRESS) {
+            // Shortcut: This almost never happens, but if validation finishes immediately, return without sleeping.
+            return new UploadStatusAndMessages(uploadId, validationStatus.getMessageList(),
+                    validationStatus.getStatus());
+        }
+
+        // Poll until complete or until timeout.
+        for (int i = 0; i < pollMaxIterations; i++) {
+            // Sleep.
+            if (pollTimeMillis > 0) {
+                try {
+                    Thread.sleep(pollTimeMillis);
+                } catch (InterruptedException ex) {
+                    LOG.error("Interrupted while polling for validation status: " + ex.getMessage(), ex);
+                }
+            }
+
+            // Check validation status
+            Upload upload = clientManager.getClient(ForWorkersApi.class).getUploadById(uploadId).execute().body();
+            if (upload.getStatus() != UploadStatus.VALIDATION_IN_PROGRESS) {
+                return new UploadStatusAndMessages(uploadId, upload.getValidationMessageList(), upload.getStatus());
+            }
+        }
+
+        // If we exit the loop, that means we timed out.
+        throw new AsyncTimeoutException("Timed out waiting for upload " + uploadId + " to complete");
     }
 
     /** Gets an upload by record ID. */

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/UploadStatusAndMessages.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/helper/UploadStatusAndMessages.java
@@ -1,0 +1,39 @@
+package org.sagebionetworks.bridge.workerPlatform.helper;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.sagebionetworks.bridge.rest.model.UploadStatus;
+
+/**
+ * Contains an upload status and validation message list. This is primarily to hold pertinent data from both Upload and
+ * UploadValidationStatus without hacking up either class.
+ */
+public class UploadStatusAndMessages {
+    private final String uploadId;
+    private final List<String> messageList;
+    private final UploadStatus status;
+
+    /** Constructs the UploadStatusAndMessages. */
+    public UploadStatusAndMessages(String uploadId, List<String> messageList, UploadStatus status) {
+        this.uploadId = uploadId;
+        this.messageList = messageList != null ? messageList : ImmutableList.of();
+        this.status = status;
+    }
+
+    /** Upload ID. */
+    public String getUploadId() {
+        return uploadId;
+    }
+
+    /** List of upload validation messages. */
+    public List<String> getMessageList() {
+        return messageList;
+    }
+
+    /** Upload status, eg VALIDATION_IN_PROGRESS, VALIDATION_FAILED, SUCCEEDED. */
+    public UploadStatus getStatus() {
+        return status;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorProcessIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/uploadredrive/UploadRedriveWorkerProcessorProcessIdTest.java
@@ -12,8 +12,8 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.rest.model.Upload;
 import org.sagebionetworks.bridge.rest.model.UploadStatus;
-import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
 import org.sagebionetworks.bridge.workerPlatform.helper.BridgeHelper;
+import org.sagebionetworks.bridge.workerPlatform.helper.UploadStatusAndMessages;
 
 public class UploadRedriveWorkerProcessorProcessIdTest {
     private static final String RECORD_ID = "my-record";
@@ -33,15 +33,16 @@ public class UploadRedriveWorkerProcessorProcessIdTest {
     @Test
     public void byUploadId() throws Exception {
         // Mock Bridge Helper.
-        UploadValidationStatus status = new UploadValidationStatus().status(UploadStatus.SUCCEEDED);
-        when(mockBridgeHelper.completeUploadSession(UPLOAD_ID, true, true)).thenReturn(status);
+        UploadStatusAndMessages status = new UploadStatusAndMessages(UPLOAD_ID, null,
+                UploadStatus.SUCCEEDED);
+        when(mockBridgeHelper.redriveUpload(UPLOAD_ID)).thenReturn(status);
 
         // Execute.
         Multiset<String> metrics = TreeMultiset.create();
         processor.processId(UPLOAD_ID, RedriveType.UPLOAD_ID, metrics);
 
         // Verify bridge call.
-        verify(mockBridgeHelper).completeUploadSession(UPLOAD_ID, true, true);
+        verify(mockBridgeHelper).redriveUpload(UPLOAD_ID);
 
         // Verify metrics.
         assertEquals(metrics.size(), 1);
@@ -54,15 +55,16 @@ public class UploadRedriveWorkerProcessorProcessIdTest {
         Upload upload = new Upload().uploadId(UPLOAD_ID);
         when(mockBridgeHelper.getUploadByRecordId(RECORD_ID)).thenReturn(upload);
 
-        UploadValidationStatus status = new UploadValidationStatus().status(UploadStatus.VALIDATION_FAILED);
-        when(mockBridgeHelper.completeUploadSession(UPLOAD_ID, true, true)).thenReturn(status);
+        UploadStatusAndMessages status = new UploadStatusAndMessages(UPLOAD_ID, null,
+                UploadStatus.VALIDATION_FAILED);
+        when(mockBridgeHelper.redriveUpload(UPLOAD_ID)).thenReturn(status);
 
         // Execute.
         Multiset<String> metrics = TreeMultiset.create();
         processor.processId(RECORD_ID, RedriveType.RECORD_ID, metrics);
 
         // Verify bridge call.
-        verify(mockBridgeHelper).completeUploadSession(UPLOAD_ID, true, true);
+        verify(mockBridgeHelper).redriveUpload(UPLOAD_ID);
 
         // Verify metrics.
         assertEquals(metrics.size(), 1);

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/BridgeHelperTest.java
@@ -2,10 +2,17 @@ package org.sagebionetworks.bridge.workerPlatform.helper;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import retrofit2.Call;
@@ -14,10 +21,13 @@ import retrofit2.Response;
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.model.Upload;
+import org.sagebionetworks.bridge.rest.model.UploadStatus;
 import org.sagebionetworks.bridge.rest.model.UploadValidationStatus;
+import org.sagebionetworks.bridge.workerPlatform.exceptions.AsyncTimeoutException;
 
 @SuppressWarnings("unchecked")
 public class BridgeHelperTest {
+    private static final List<String> DUMMY_MESSAGE_LIST = ImmutableList.of("This is a message");
     private static final String RECORD_ID = "dummy-record";
     private static final String UPLOAD_ID = "dummy-upload";
 
@@ -26,32 +36,127 @@ public class BridgeHelperTest {
 
     @BeforeMethod
     public void setup() {
+        // Mock API.
         mockWorkerApi = mock(ForWorkersApi.class);
 
         ClientManager mockClientManager = mock(ClientManager.class);
         when(mockClientManager.getClient(ForWorkersApi.class)).thenReturn(mockWorkerApi);
 
+        // Create bridge helper.
         bridgeHelper = new BridgeHelper();
         bridgeHelper.setClientManager(mockClientManager);
+
+        // Set poll settings so unit tests don't take forever.
+        bridgeHelper.setPollTimeMillis(0);
+        bridgeHelper.setPollMaxIterations(3);
     }
 
     @Test
-    public void completeUploadSession() throws Exception {
-        // Mock API.
-        UploadValidationStatus status = new UploadValidationStatus();
+    public void redriveUpload_completeImmediately() throws Exception {
+        // Mock Upload Complete.
+        UploadValidationStatus status = new UploadValidationStatus().id(UPLOAD_ID).messageList(DUMMY_MESSAGE_LIST)
+                .status(UploadStatus.SUCCEEDED);
+        mockUploadComplete(status);
+
+        // Execute and verify.
+        UploadStatusAndMessages outputStatus = bridgeHelper.redriveUpload(UPLOAD_ID);
+        assertUploadStatusAndMessages(outputStatus);
+
+        verify(mockWorkerApi).completeUploadSession(UPLOAD_ID, false, true);
+        verify(mockWorkerApi, never()).getUploadById(any());
+    }
+
+    @Test
+    public void redriveUpload_1Poll() throws Exception {
+        // Mock Upload Complete.
+        UploadValidationStatus status = new UploadValidationStatus().id(UPLOAD_ID).status(
+                UploadStatus.VALIDATION_IN_PROGRESS);
+        mockUploadComplete(status);
+
+        // Mock polling for upload.
+        Upload upload = new Upload().uploadId(UPLOAD_ID).validationMessageList(DUMMY_MESSAGE_LIST).status(
+                UploadStatus.SUCCEEDED);
+        Call<Upload> call = makeGetUploadByIdCall(upload);
+        when(mockWorkerApi.getUploadById(UPLOAD_ID)).thenReturn(call);
+
+        // Execute and verify.
+        UploadStatusAndMessages outputStatus = bridgeHelper.redriveUpload(UPLOAD_ID);
+        assertUploadStatusAndMessages(outputStatus);
+
+        verify(mockWorkerApi).completeUploadSession(UPLOAD_ID, false, true);
+        verify(mockWorkerApi).getUploadById(UPLOAD_ID);
+    }
+
+    @Test
+    public void redriveUpload_multiplePolls() throws Exception {
+        // Mock Upload Complete.
+        UploadValidationStatus status = new UploadValidationStatus().id(UPLOAD_ID).status(
+                UploadStatus.VALIDATION_IN_PROGRESS);
+        mockUploadComplete(status);
+
+        // Mock polling for upload.
+        Upload uploadInProgress = new Upload().uploadId(UPLOAD_ID).status(UploadStatus.VALIDATION_IN_PROGRESS);
+        Call<Upload> callInProgress = makeGetUploadByIdCall(uploadInProgress);
+
+        Upload uploadSuccess = new Upload().uploadId(UPLOAD_ID).validationMessageList(DUMMY_MESSAGE_LIST).status(
+                UploadStatus.SUCCEEDED);
+        Call<Upload> callSuccess = makeGetUploadByIdCall(uploadSuccess);
+
+        when(mockWorkerApi.getUploadById(UPLOAD_ID)).thenReturn(callInProgress, callInProgress, callSuccess);
+
+        // Execute and verify.
+        UploadStatusAndMessages outputStatus = bridgeHelper.redriveUpload(UPLOAD_ID);
+        assertUploadStatusAndMessages(outputStatus);
+
+        verify(mockWorkerApi).completeUploadSession(UPLOAD_ID, false, true);
+        verify(mockWorkerApi, times(3)).getUploadById(UPLOAD_ID);
+    }
+
+    @Test
+    public void redriveUpload_timeout() throws Exception {
+        // Mock Upload Complete.
+        UploadValidationStatus status = new UploadValidationStatus().id(UPLOAD_ID).status(
+                UploadStatus.VALIDATION_IN_PROGRESS);
+        mockUploadComplete(status);
+
+        // Mock polling for upload.
+        Upload uploadInProgress = new Upload().uploadId(UPLOAD_ID).status(UploadStatus.VALIDATION_IN_PROGRESS);
+        Call<Upload> callInProgress = makeGetUploadByIdCall(uploadInProgress);
+        when(mockWorkerApi.getUploadById(UPLOAD_ID)).thenReturn(callInProgress);
+
+        // Execute and verify.
+        try {
+            bridgeHelper.redriveUpload(UPLOAD_ID);
+            fail("expected exception");
+        } catch (AsyncTimeoutException ex) {
+            // expected exception
+        }
+
+        verify(mockWorkerApi).completeUploadSession(UPLOAD_ID, false, true);
+        verify(mockWorkerApi, times(3)).getUploadById(UPLOAD_ID);
+    }
+
+    private void mockUploadComplete(UploadValidationStatus status) throws Exception {
         Response<UploadValidationStatus> response = Response.success(status);
 
         Call<UploadValidationStatus> call = mock(Call.class);
         when(call.execute()).thenReturn(response);
 
         when(mockWorkerApi.completeUploadSession(any(), any(), any())).thenReturn(call);
+    }
 
-        // Execute and verify.
-        UploadValidationStatus outputStatus = bridgeHelper.completeUploadSession(UPLOAD_ID, true,
-                true);
-        assertSame(outputStatus, status);
+    private static Call<Upload> makeGetUploadByIdCall(Upload upload) throws Exception {
+        Response<Upload> response = Response.success(upload);
 
-        verify(mockWorkerApi).completeUploadSession(UPLOAD_ID, true, true);
+        Call<Upload> call = mock(Call.class);
+        when(call.execute()).thenReturn(response);
+        return call;
+    }
+
+    private static void assertUploadStatusAndMessages(UploadStatusAndMessages status) {
+        assertEquals(UPLOAD_ID, status.getUploadId());
+        assertEquals(DUMMY_MESSAGE_LIST, status.getMessageList());
+        assertEquals(UploadStatus.SUCCEEDED, status.getStatus());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/UploadStatusAndMessagesTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/helper/UploadStatusAndMessagesTest.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.bridge.workerPlatform.helper;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.rest.model.UploadStatus;
+
+public class UploadStatusAndMessagesTest {
+    @Test
+    public void nullMessageListConvertedToEmpty() {
+        UploadStatusAndMessages status = new UploadStatusAndMessages("dummy-id", null,
+                UploadStatus.UNKNOWN);
+        assertNotNull(status.getMessageList());
+        assertTrue(status.getMessageList().isEmpty());
+    }
+}


### PR DESCRIPTION
This moves the upload polling from server-side to client-side to reduce the number of long requests the server has to deal with. This helps reduce the number of socket timeouts.

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco coverage)
* integ tests