### PR TITLE
UserDataDownload should handle deleted tables gracefully

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParameters.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParameters.java
@@ -2,17 +2,24 @@ package org.sagebionetworks.bridge.udd.synapse;
 
 import java.io.File;
 
-import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 /** Params needed to execute the SynapseDownloadSurveyTask. */
 public class SynapseDownloadSurveyParameters {
+    private final String studyId;
     private final String synapseTableId;
     private final File tempDir;
 
     /** Private constructor. To build, use builder. */
-    private SynapseDownloadSurveyParameters(String synapseTableId, File tempDir) {
+    private SynapseDownloadSurveyParameters(String studyId, String synapseTableId, File tempDir) {
+        this.studyId = studyId;
         this.synapseTableId = synapseTableId;
         this.tempDir = tempDir;
+    }
+
+    /** Study ID for this survey download. */
+    public String getStudyId() {
+        return studyId;
     }
 
     /** ID of the Synapse table with the survey metadata. */
@@ -27,8 +34,15 @@ public class SynapseDownloadSurveyParameters {
 
     /** Parameter class builder. */
     public static class Builder {
+        private String studyId;
         private String synapseTableId;
         private File tempDir;
+
+        /** @see SynapseDownloadSurveyParameters#getStudyId */
+        public Builder withStudyId(String studyId) {
+            this.studyId = studyId;
+            return this;
+        }
 
         /** @see SynapseDownloadSurveyParameters#getSynapseTableId */
         public Builder withSynapseTableId(String synapseTableId) {
@@ -43,7 +57,11 @@ public class SynapseDownloadSurveyParameters {
 
         /** Builds the parameters object and validates parameters. */
         public SynapseDownloadSurveyParameters build() {
-            if (Strings.isNullOrEmpty(synapseTableId)) {
+            if (StringUtils.isBlank(studyId)) {
+                throw new IllegalStateException("studyId must be specified");
+            }
+
+            if (StringUtils.isBlank(synapseTableId)) {
                 throw new IllegalStateException("synapseTableId must be specified");
             }
 
@@ -51,7 +69,7 @@ public class SynapseDownloadSurveyParameters {
                 throw new IllegalStateException("tempDir must be specified");
             }
 
-            return new SynapseDownloadSurveyParameters(synapseTableId, tempDir);
+            return new SynapseDownloadSurveyParameters(studyId, synapseTableId, tempDir);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTask.java
@@ -6,11 +6,14 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Stopwatch;
 import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.repo.model.table.TableEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.file.FileHelper;
+import org.sagebionetworks.bridge.udd.dynamodb.DynamoHelper;
+import org.sagebionetworks.bridge.udd.exceptions.AsyncTaskExecutionException;
 import org.sagebionetworks.bridge.udd.exceptions.AsyncTimeoutException;
 
 /**
@@ -25,6 +28,7 @@ public class SynapseDownloadSurveyTask implements Callable<File> {
 
     // Helpers and config objects. Originates from Spring configs and is passed in through setters using a similar
     // pattern.
+    private DynamoHelper dynamoHelper;
     private FileHelper fileHelper;
     private SynapseHelper synapseHelper;
 
@@ -38,6 +42,16 @@ public class SynapseDownloadSurveyTask implements Callable<File> {
         this.params = params;
     }
 
+    /** DynamoDB helper, used to delete entries from the table mappings when the table has been deleted. */
+    public final void setDynamoHelper(DynamoHelper dynamoHelper) {
+        this.dynamoHelper = dynamoHelper;
+    }
+
+    // Package-scoped for unit tests.
+    DynamoHelper getDynamoHelper() {
+        return dynamoHelper;
+    }
+
     /**
      * Wrapper class around the file system. Used by unit tests to test the functionality without hitting the real file
      * system.
@@ -46,9 +60,19 @@ public class SynapseDownloadSurveyTask implements Callable<File> {
         this.fileHelper = fileHelper;
     }
 
+    // Package-scoped for unit tests.
+    FileHelper getFileHelper() {
+        return fileHelper;
+    }
+
     /** Synapse helper, used to download survey metadata from Synapse. */
     public final void setSynapseHelper(SynapseHelper synapseHelper) {
         this.synapseHelper = synapseHelper;
+    }
+
+    // Package-scoped for unit tests.
+    SynapseHelper getSynapseHelper() {
+        return synapseHelper;
     }
 
     /**
@@ -57,11 +81,18 @@ public class SynapseDownloadSurveyTask implements Callable<File> {
      * @return the file containing the survey metadata in CSV format, never null
      */
     @Override
-    public File call() throws AsyncTimeoutException, SynapseException {
+    public File call() throws AsyncTaskExecutionException, AsyncTimeoutException, SynapseException {
         String synapseTableId = params.getSynapseTableId();
 
         // get table name
-        TableEntity table = synapseHelper.getTable(synapseTableId);
+        TableEntity table;
+        try {
+            table = synapseHelper.getTable(synapseTableId);
+        } catch (SynapseNotFoundException ex) {
+            // Clean this table from the table mapping to prevent future errors.
+            dynamoHelper.deleteSynapseSurveyTableMapping(params.getStudyId(), synapseTableId);
+            throw new AsyncTaskExecutionException("Survey table " + synapseTableId + " no longer exists");
+        }
 
         // download table
         File surveyFile = fileHelper.newFile(params.getTempDir(), table.getName() + ".csv");

--- a/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessor.java
@@ -95,7 +95,7 @@ public class BridgeUddProcessor {
 
             Map<String, UploadSchema> synapseToSchemaMap = dynamoHelper.getSynapseTableIdsForStudy(studyId);
             Set<String> surveyTableIdSet = dynamoHelper.getSynapseSurveyTablesForStudy(studyId);
-            PresignedUrlInfo presignedUrlInfo = synapsePackager.packageSynapseData(synapseToSchemaMap,
+            PresignedUrlInfo presignedUrlInfo = synapsePackager.packageSynapseData(studyId, synapseToSchemaMap,
                     healthCode, request, surveyTableIdSet);
 
             if (presignedUrlInfo == null) {

--- a/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperDeleteSurveyMappingTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperDeleteSurveyMappingTest.java
@@ -1,0 +1,110 @@
+package org.sagebionetworks.bridge.udd.dynamodb;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+import com.google.common.collect.Iterables;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@SuppressWarnings("unchecked")
+public class DynamoHelperDeleteSurveyMappingTest {
+    private static final String STUDY_ID = "my-study";
+    private static final String TABLE_ID_FOO = "table-foo";
+    private static final String TABLE_ID_BAR = "table-bar";
+
+    private DynamoHelper helper;
+    private Table mockSynapseSurveyTable;
+
+    @BeforeMethod
+    public void before() {
+        mockSynapseSurveyTable = mock(Table.class);
+
+        helper = new DynamoHelper();
+        helper.setDdbSynapseSurveyTablesTable(mockSynapseSurveyTable);
+    }
+
+    @Test
+    public void noItem() {
+        when(mockSynapseSurveyTable.getItem(DynamoHelper.ATTR_STUDY_ID, STUDY_ID)).thenReturn(null);
+        helper.deleteSynapseSurveyTableMapping(STUDY_ID, TABLE_ID_FOO);
+        verify(mockSynapseSurveyTable, never()).updateItem(any());
+    }
+
+    @Test
+    public void noSet() {
+        when(mockSynapseSurveyTable.getItem(DynamoHelper.ATTR_STUDY_ID, STUDY_ID)).thenReturn(new Item());
+        helper.deleteSynapseSurveyTableMapping(STUDY_ID, TABLE_ID_FOO);
+        verify(mockSynapseSurveyTable, never()).updateItem(any());
+    }
+
+    @Test
+    public void setDoesntContainTableId() {
+        Item item = new Item().withStringSet(DynamoHelper.ATTR_TABLE_ID_SET, "table-other");
+        when(mockSynapseSurveyTable.getItem(DynamoHelper.ATTR_STUDY_ID, STUDY_ID)).thenReturn(item);
+        helper.deleteSynapseSurveyTableMapping(STUDY_ID, TABLE_ID_FOO);
+        verify(mockSynapseSurveyTable, never()).updateItem(any());
+    }
+
+    @Test
+    public void normalCase() {
+        // Mock DDB table.
+        Item item = new Item().withStringSet(DynamoHelper.ATTR_TABLE_ID_SET, TABLE_ID_FOO, TABLE_ID_BAR);
+        when(mockSynapseSurveyTable.getItem(DynamoHelper.ATTR_STUDY_ID, STUDY_ID)).thenReturn(item);
+
+        // Execute and validate.
+        helper.deleteSynapseSurveyTableMapping(STUDY_ID, TABLE_ID_FOO);
+
+        ArgumentCaptor<UpdateItemSpec> updateItemSpecCaptor = ArgumentCaptor.forClass(UpdateItemSpec.class);
+        verify(mockSynapseSurveyTable).updateItem(updateItemSpecCaptor.capture());
+
+        UpdateItemSpec updateItemSpec = updateItemSpecCaptor.getValue();
+        assertEquals(updateItemSpec.getUpdateExpression(), "set " + DynamoHelper.ATTR_TABLE_ID_SET + "=:s");
+
+        Collection<KeyAttribute> keyComponents = updateItemSpec.getKeyComponents();
+        assertEquals(keyComponents.size(), 1);
+        KeyAttribute key = Iterables.getOnlyElement(keyComponents);
+        assertEquals(key.getName(), DynamoHelper.ATTR_STUDY_ID);
+        assertEquals(key.getValue(), STUDY_ID);
+
+        Map<String, Object> valueMap = updateItemSpec.getValueMap();
+        assertEquals(valueMap.size(), 1);
+        Set<String> tableIdSet = (Set<String>) valueMap.get(":s");
+        assertTrue(tableIdSet.contains(TABLE_ID_BAR));
+    }
+
+    @Test
+    public void removeLastTableId() {
+        // Mock DDB table.
+        Item item = new Item().withStringSet(DynamoHelper.ATTR_TABLE_ID_SET, TABLE_ID_FOO);
+        when(mockSynapseSurveyTable.getItem(DynamoHelper.ATTR_STUDY_ID, STUDY_ID)).thenReturn(item);
+
+        // Execute and validate. Update params already tested in a previous test. Just test the submitted table ID set
+        // is null.
+        helper.deleteSynapseSurveyTableMapping(STUDY_ID, TABLE_ID_FOO);
+
+        ArgumentCaptor<UpdateItemSpec> updateItemSpecCaptor = ArgumentCaptor.forClass(UpdateItemSpec.class);
+        verify(mockSynapseSurveyTable).updateItem(updateItemSpecCaptor.capture());
+
+        UpdateItemSpec updateItemSpec = updateItemSpecCaptor.getValue();
+        Map<String, Object> valueMap = updateItemSpec.getValueMap();
+        assertEquals(valueMap.size(), 1);
+        assertTrue(valueMap.containsKey(":s"));
+        assertNull(valueMap.get(":s"));
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.udd.dynamodb;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -17,6 +18,7 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoQueryHelper;
 import org.sagebionetworks.bridge.schema.UploadSchema;
+import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 
 public class DynamoHelperTest {
     private static final String DUMMY_FIELD_DEF_LIST_JSON = "[\n" +
@@ -25,6 +27,8 @@ public class DynamoHelperTest {
             "       \"type\":\"STRING\"\n" +
             "   }\n" +
             "]";
+    private static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId("test-study")
+            .withSchemaId("test-schema").withRevision(42).build();
 
     @Test
     public void testGetStudy() {
@@ -161,5 +165,17 @@ public class DynamoHelperTest {
 
     private static Item makeSynapseMapDdbItem(String schemaKey, String synapseTableId) {
         return new Item().withString("schemaKey", schemaKey).withString("tableId", synapseTableId);
+    }
+
+    @Test
+    public void deleteSynapseTableIdMapping() {
+        // Set up.
+        Table mockSynapseMapTable = mock(Table.class);
+        DynamoHelper helper = new DynamoHelper();
+        helper.setDdbSynapseMapTable(mockSynapseMapTable);
+
+        // Execute and validate.
+        helper.deleteSynapseTableIdMapping(TEST_SCHEMA_KEY);
+        verify(mockSynapseMapTable).deleteItem("schemaKey", TEST_SCHEMA_KEY.toString());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParametersTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParametersTest.java
@@ -9,27 +9,55 @@ import java.io.File;
 import org.testng.annotations.Test;
 
 public class SynapseDownloadSurveyParametersTest {
+    private static final String STUDY_ID = "my-study";
+    private static final String SYNAPSE_TABLE_ID = "syn1234";
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*studyId.*")
+    public void nullStudyId() {
+        makeValidBuilder().withStudyId(null).build();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*studyId.*")
+    public void emptyStudyId() {
+        makeValidBuilder().withStudyId("").build();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*studyId.*")
+    public void blankStudyId() {
+        makeValidBuilder().withStudyId("   ").build();
+    }
+
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*synapseTableId.*")
     public void nullTableId() {
-        new SynapseDownloadSurveyParameters.Builder().withTempDir(mock(File.class)).build();
+        makeValidBuilder().withSynapseTableId(null).build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*synapseTableId.*")
     public void emptyTableId() {
-        new SynapseDownloadSurveyParameters.Builder().withSynapseTableId("").withTempDir(mock(File.class)).build();
+        makeValidBuilder().withSynapseTableId("").build();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*synapseTableId.*")
+    public void blankTableId() {
+        makeValidBuilder().withSynapseTableId("   ").build();
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*tempDir.*")
     public void nullTempDir() {
-        new SynapseDownloadSurveyParameters.Builder().withSynapseTableId("test-table").build();
+        makeValidBuilder().withTempDir(null).build();
     }
 
     @Test
     public void happyCase() {
         File mockFile = mock(File.class);
-        SynapseDownloadSurveyParameters params = new SynapseDownloadSurveyParameters.Builder()
-                .withSynapseTableId("test-table").withTempDir(mockFile).build();
-        assertEquals(params.getSynapseTableId(), "test-table");
+        SynapseDownloadSurveyParameters params = makeValidBuilder().withTempDir(mockFile).build();
+        assertEquals(params.getStudyId(), STUDY_ID);
+        assertEquals(params.getSynapseTableId(), SYNAPSE_TABLE_ID);
         assertSame(params.getTempDir(), mockFile);
+    }
+
+    private static SynapseDownloadSurveyParameters.Builder makeValidBuilder() {
+        return new SynapseDownloadSurveyParameters.Builder().withStudyId(STUDY_ID).withSynapseTableId(SYNAPSE_TABLE_ID)
+                .withTempDir(mock(File.class));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTaskTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -17,17 +18,23 @@ import java.io.Writer;
 
 import com.google.common.io.CharStreams;
 import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.repo.model.table.TableEntity;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
+import org.sagebionetworks.bridge.udd.dynamodb.DynamoHelper;
+import org.sagebionetworks.bridge.udd.exceptions.AsyncTaskExecutionException;
 
+@SuppressWarnings("unchecked")
 public class SynapseDownloadSurveyTaskTest {
+    private static final String STUDY_ID = "my-study";
     private static final String TEST_FILE_HANDLE = "test-file-handle";
     private static final String TEST_SYNAPSE_TABLE_ID = "test-table";
     private static final String TEST_SYNAPSE_TABLE_NAME = "Test Table";
 
+    private DynamoHelper dynamoHelper;
     private InMemoryFileHelper fileHelper;
     private SynapseHelper synapseHelper;
     private SynapseDownloadSurveyTask task;
@@ -35,6 +42,9 @@ public class SynapseDownloadSurveyTaskTest {
 
     @BeforeMethod
     public void setup() throws Exception {
+        // Mock Dynamo helper.
+        dynamoHelper = mock(DynamoHelper.class);
+
         // mock Synapse helper
         synapseHelper = mock(SynapseHelper.class);
 
@@ -51,13 +61,34 @@ public class SynapseDownloadSurveyTaskTest {
         tmpDir = fileHelper.createTempDir();
 
         // create params
-        SynapseDownloadSurveyParameters params = new SynapseDownloadSurveyParameters.Builder()
+        SynapseDownloadSurveyParameters params = new SynapseDownloadSurveyParameters.Builder().withStudyId(STUDY_ID)
                 .withSynapseTableId(TEST_SYNAPSE_TABLE_ID).withTempDir(tmpDir).build();
 
         // create task
         task = new SynapseDownloadSurveyTask(params);
+        task.setDynamoHelper(dynamoHelper);
         task.setFileHelper(fileHelper);
         task.setSynapseHelper(synapseHelper);
+    }
+
+    @Test
+    public void tableDoesntExist() throws Exception {
+        // getTable() throws.
+        when(synapseHelper.getTable(TEST_SYNAPSE_TABLE_ID)).thenThrow(SynapseNotFoundException.class);
+
+        // Execute (throws exception).
+        try {
+            task.call();
+            fail("expected exception");
+        } catch (AsyncTaskExecutionException ex) {
+            assertEquals(ex.getMessage(), "Survey table " + TEST_SYNAPSE_TABLE_ID + " no longer exists");
+        }
+
+        // Verify we delete the schema from the table mapping.
+        verify(dynamoHelper).deleteSynapseSurveyTableMapping(STUDY_ID, TEST_SYNAPSE_TABLE_ID);
+
+        // Verify file helper is clean.
+        postValidation();
     }
 
     @Test
@@ -129,7 +160,7 @@ public class SynapseDownloadSurveyTaskTest {
     }
 
     // We can't use an AfterMethod, because AfterMethod doesn't report which method failed.
-    private void postValidation() throws Exception {
+    private void postValidation() {
         fileHelper.deleteDir(tmpDir);
         assertTrue(fileHelper.isEmpty());
     }

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelperBulkDownloadTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelperBulkDownloadTest.java
@@ -122,8 +122,8 @@ public class SynapseHelperBulkDownloadTest {
         }
         assertNotNull(thrownEx);
 
-        // Because of retries, we call this 5 times.
-        verify(mockClient, times(5)).getBulkFileDownloadResults(anyString());
+        // Because of retries, we call this 2 times.
+        verify(mockClient, times(2)).getBulkFileDownloadResults(anyString());
         postValidation();
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelperQueryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelperQueryTest.java
@@ -111,7 +111,7 @@ public class SynapseHelperQueryTest {
         }
         assertNotNull(thrownEx);
 
-        // Because of retries, we call this 5 times.
-        verify(mockClient, times(5)).downloadCsvFromTableAsyncGet(anyString(), anyString());
+        // Because of retries, we call this 2 times.
+        verify(mockClient, times(2)).downloadCsvFromTableAsyncGet(anyString(), anyString());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorTest.java
@@ -190,7 +190,7 @@ public class BridgeUddProcessorTest {
     }
 
     private void mockPackagerWithResult(PresignedUrlInfo presignedUrlInfo) throws Exception {
-        when(mockPackager.packageSynapseData(same(MOCK_SYNAPSE_TO_SCHEMA), eq(HEALTH_CODE),
+        when(mockPackager.packageSynapseData(eq(STUDY_ID), same(MOCK_SYNAPSE_TO_SCHEMA), eq(HEALTH_CODE),
                 any(BridgeUddRequest.class), same(MOCK_SURVEY_TABLE_ID_SET))).thenReturn(presignedUrlInfo);
     }
 


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2129

Catches the SynapseNotFoundException and deletes the entry from the mapping in DDB before rethrowing.

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* manual tests: deleted table, deleted survey metadata, deleted last survey, successful case to make sure errors are gone