### PR TITLE
FitBit worker should not retry infinitely on users

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/exceptions/WorkerException.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/exceptions/WorkerException.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.bridge.workerPlatform.exceptions;
+
+/** Generic exception signifying something went wrong with the worker. */
+@SuppressWarnings("serial")
+public class WorkerException extends Exception {
+    public WorkerException() {
+    }
+
+    public WorkerException(String message) {
+        super(message);
+    }
+
+    public WorkerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WorkerException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2055

Added an error limit so that the FitBit worker doesn't retry infinitely on users.

Testing done:
* Hacked up my local server to throw a 500 on OAuthController.getAccessToken() and tested manually.
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* integ tests