### PR TITLE
add BridgeAdmin and BridgeStaff groups to FitBit tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.18</version>
+            <version>2.7.20</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/fitbit/worker/TableProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/fitbit/worker/TableProcessor.java
@@ -6,18 +6,21 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.Table;
+import com.google.common.collect.ImmutableSet;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exceptions.BridgeSynapseException;
 import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.fitbit.schema.ColumnSchema;
@@ -32,14 +35,25 @@ import org.sagebionetworks.bridge.synapse.SynapseHelper;
 @Component
 public class TableProcessor {
     // Visible for testing
+    static final String CONFIG_KEY_TEAM_BRIDGE_ADMIN = "team.bridge.admin";
+    static final String CONFIG_KEY_TEAM_BRIDGE_STAFF = "team.bridge.staff";
     static final String DDB_KEY_STUDY_ID = "studyId";
     static final String DDB_KEY_SYNAPSE_TABLE_ID = "synapseTableId";
     static final String DDB_KEY_TABLE_ID = "tableId";
 
+    private long bridgeAdminTeamId;
+    private long bridgeStaffTeamId;
     private Table ddbTablesMap;
     private FileHelper fileHelper;
     private SynapseHelper synapseHelper;
     private long synapsePrincipalId;
+
+    /** Bridge config. */
+    @Autowired
+    public final void setBridgeConfig(Config bridgeConfig) {
+        this.bridgeAdminTeamId = bridgeConfig.getInt(CONFIG_KEY_TEAM_BRIDGE_ADMIN);
+        this.bridgeStaffTeamId = bridgeConfig.getInt(CONFIG_KEY_TEAM_BRIDGE_STAFF);
+    }
 
     /** DynamoDB table which maps the study ID and table ID (table name) to a Synapse table ID. */
     @Resource(name = "ddbTablesMap")
@@ -141,10 +155,11 @@ public class TableProcessor {
         if (!tableExists) {
             // Delegate table creation to SynapseHelper.
             Study study = ctx.getStudy();
-            long dataAccessTeamId = study.getSynapseDataAccessTeamId();
+            Set<Long> readOnlyPrincipalIdSet = ImmutableSet.of(bridgeStaffTeamId, study.getSynapseDataAccessTeamId());
+            Set<Long> adminPrincipalIdSet = ImmutableSet.of(bridgeAdminTeamId, synapsePrincipalId);
             String projectId = study.getSynapseProjectId();
-            String newSynapseTableId = synapseHelper.createTableWithColumnsAndAcls(columnModelList, dataAccessTeamId,
-                    synapsePrincipalId, projectId, tableId);
+            String newSynapseTableId = synapseHelper.createTableWithColumnsAndAcls(columnModelList,
+                    readOnlyPrincipalIdSet, adminPrincipalIdSet, projectId, tableId);
 
             // write back to DDB table
             setSynapseTableIdToDdb(study.getIdentifier(), tableId, newSynapseTableId);

--- a/src/main/resources/BridgeWorkerPlatform.conf
+++ b/src/main/resources/BridgeWorkerPlatform.conf
@@ -17,6 +17,12 @@ synapse.rate.limit.per.second = 10
 synapse.get.column.models.rate.limit.per.minute = 12
 workerPlatform.request.sqs.sleep.time.millis=125
 
+# Synapse Team IDs, used by the FitBitWorker when creating FitBit tables in Synapse.
+team.bridge.admin = 3388390
+team.bridge.staff = 3388389
+prod.team.bridge.admin = 3388392
+prod.team.bridge.staff = 3388391
+
 # Currently, the redrive worker uses the general threadpool. Synchronous upload complete takes ~5 seconds, so we'll
 # have 6 threads to make sure we're probabilistically never blocked on thread pools.
 threadpool.general.count = 6


### PR DESCRIPTION
Requires https://github.com/Sage-Bionetworks/bridge-base/pull/50

This change adds the BridgeAdmin and BridgeStaff groups to FitBit tables, so we don't need to log in as the BridgeExporter to diagnose FitBit data.

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* worker integ tests
* deleted old tables and mappings, verified permissions on new tables