### PR TITLE
Update SynapseJavaClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>157.0</version>
+            <version>268.02</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackager.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackager.java
@@ -22,6 +22,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import org.joda.time.DateTime;
 import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.SynapseServiceUnavailable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -368,8 +369,7 @@ public class SynapsePackager {
         // The real exception is in the inner exception (if it's an ExecutionException).
         Throwable originalEx = ex.getCause();
 
-        if (originalEx instanceof SynapseServerException &&
-                ((SynapseServerException) originalEx).getStatusCode() == 503) {
+        if (originalEx instanceof SynapseServiceUnavailable) {
             throw new SynapseUnavailableException("Synapse not in writable state");
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
@@ -213,7 +213,7 @@ public class SpringConfig {
     @Bean(name="workerPlatformSynapseClient")
     public SynapseClient synapseClient() {
         SynapseClient synapseClient = new SynapseAdminClientImpl();
-        synapseClient.setUserName(bridgeConfig().get("synapse.user"));
+        synapseClient.setUsername(bridgeConfig().get("synapse.user"));
         synapseClient.setApiKey(bridgeConfig().get("synapse.api.key"));
         return synapseClient;
     }

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/DefaultTableTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/DefaultTableTaskTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import org.joda.time.LocalDate;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -94,7 +94,7 @@ public class DefaultTableTaskTest {
     @Test
     public void errorVerifyingTable() throws Exception {
         // Mock getTable()
-        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(SynapseServerException.class);
+        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(UnknownSynapseServerException.class);
 
         // Execute (throws exception).
         try {

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SchemaBasedTableTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SchemaBasedTableTaskTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import org.joda.time.LocalDate;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -116,7 +116,7 @@ public class SchemaBasedTableTaskTest {
     @Test
     public void errorVerifyingTable() throws Exception {
         // Mock getTable()
-        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(SynapseServerException.class);
+        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(UnknownSynapseServerException.class);
 
         // Execute (throws exception).
         try {

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackagerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackagerTest.java
@@ -39,7 +39,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.LocalDate;
 import org.mockito.ArgumentCaptor;
-import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
+import org.sagebionetworks.client.exceptions.SynapseServiceUnavailable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -355,7 +356,7 @@ public class SynapsePackagerTest {
         Map<String, String> surveyTableToResultContent = ImmutableMap.of();
 
         Map<String, ExecutionException> synapseTableToException = ImmutableMap.of("test-table-id",
-                new ExecutionException(new SynapseServerException(503)));
+                new ExecutionException(new SynapseServiceUnavailable("Service Unavailable")));
 
         setupPackager(synapseTableToSchema, synapseTableToResult, synapseTableToException, surveyTableToResultContent,
                 null);
@@ -386,7 +387,7 @@ public class SynapsePackagerTest {
 
         Map<String, String> surveyTableToResultContent = ImmutableMap.of();
         Map<String, ExecutionException> surveyTableToException = ImmutableMap.of("test-survey",
-                new ExecutionException(new SynapseServerException(503)));
+                new ExecutionException(new SynapseServiceUnavailable("Service Unavailable")));
 
         setupPackager(synapseTableToSchema, synapseTableToResult, null,
                 surveyTableToResultContent, surveyTableToException);
@@ -409,7 +410,7 @@ public class SynapsePackagerTest {
         return new Object[][] {
                 { new ExecutionException("no cause", null) },
                 { new ExecutionException("not Synapse exception", new RuntimeException()) },
-                { new ExecutionException("Synapse 400 Bad Request", new SynapseServerException(400)) },
+                { new ExecutionException("Synapse 400 Bad Request", new SynapseBadRequestException()) },
         };
     }
 
@@ -422,7 +423,7 @@ public class SynapsePackagerTest {
     @Test(expectedExceptions = SynapseUnavailableException.class,
             expectedExceptionsMessageRegExp = "Synapse not in writable state")
     public void throwSynapseReadOnlyException() throws Exception {
-        ExecutionException ex = new ExecutionException("Synapse 503 Unavailable", new SynapseServerException(503));
+        ExecutionException ex = new ExecutionException("Synapse 503 Unavailable", new SynapseServiceUnavailable("Service Unavailable"));
         SynapsePackager.rethrowIfSynapseIsReadOnly(ex);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorTest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 
-import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.SynapseServiceUnavailable;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -191,7 +191,7 @@ public class BridgeUddProcessorTest {
     @Test
     public void synapseWritableThrows() throws Exception {
         // Mock Synapse helper to throw.
-        Exception originalEx = new SynapseServerException(503, "test exception");
+        Exception originalEx = new SynapseServiceUnavailable("test exception");
         when(mockSynapseHelper.isSynapseWritable()).thenThrow(originalEx);
 
         // Execute (throws exception).


### PR DESCRIPTION
We were asked to update the SynapseJavaClient so that the Synapse team could deprecate some stuff. There were some breaking changes and some dependency conflicts we had to resolve, but there should be no functional changes.