### PR TITLE
fix FitBitWorker userWhitelist error handling

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/fitbit/worker/BridgeFitBitWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/fitbit/worker/BridgeFitBitWorkerProcessor.java
@@ -171,7 +171,7 @@ public class BridgeFitBitWorkerProcessor implements ThrowingConsumer<JsonNode> {
                         .map(healthCode -> {
                             try {
                                 return bridgeHelper.getFitBitUserForStudyAndHealthCode(studyId, healthCode);
-                            } catch (IOException ex) {
+                            } catch (IOException | RuntimeException ex) {
                                 LOG.error("Error getting FitBit auth for health code " + healthCode);
                                 return null;
                             }


### PR DESCRIPTION
Currently, if there's an error getting one user's OAuthAccessGrant (such as a 404 no OAuthAccessGrant), it'll error out the whole job. This fixes the error handling so that we can continue on to the other users.