### PR TITLE
Fix BridgeReporterProcessorTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.19.12</version>
+            <version>0.19.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.19.11</version>
+            <version>0.19.12</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/test/java/org/sagebionetworks/bridge/reporter/worker/BridgeReporterProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/reporter/worker/BridgeReporterProcessorTest.java
@@ -172,13 +172,9 @@ public class BridgeReporterProcessorTest {
         SignUpsReportGenerator signUpsGenerator = new SignUpsReportGenerator();
         signUpsGenerator.setBridgeHelper(mockBridgeHelper);
         
-        RetentionReportGenerator retentionGenerator = new RetentionReportGenerator();
-        retentionGenerator.setBridgeHelper(mockBridgeHelper);
-        
         Map<ReportType, ReportGenerator> generators = new ImmutableMap.Builder<ReportType, ReportGenerator>()
                 .put(ReportType.DAILY, uploadsGenerator).put(ReportType.WEEKLY, uploadsGenerator)
-                .put(ReportType.DAILY_SIGNUPS, signUpsGenerator)
-                .put(ReportType.DAILY_RETENTION, retentionGenerator).build();
+                .put(ReportType.DAILY_SIGNUPS, signUpsGenerator).build();
         
         // set up callback
         processor = new BridgeReporterProcessor();

--- a/src/test/java/org/sagebionetworks/bridge/reporter/worker/BridgeReporterProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/reporter/worker/BridgeReporterProcessorTest.java
@@ -86,18 +86,21 @@ public class BridgeReporterProcessorTest {
     private static final String PARTICIPANT_1 = Tests.unescapeJson("{" +
             "'id':'user1'," +
             "'sharingScope':'no_sharing'," +
+            "'roles': []," +
             "'status':'enabled'" +
             "}");
 
     private static final String PARTICIPANT_2 = Tests.unescapeJson("{" +
             "'id':'user2'," +
             "'sharingScope':'all_qualified_researchers'," +
+            "'roles': []," +
             "'status':'enabled'" +
             "}");
 
     private static final String PARTICIPANT_3 = Tests.unescapeJson("{" +
             "'id':'user3'," +
             "'sharingScope':'no_sharing'," +
+            "'roles': []," +
             "'status':'unverified'" +
             "}");
 
@@ -169,9 +172,13 @@ public class BridgeReporterProcessorTest {
         SignUpsReportGenerator signUpsGenerator = new SignUpsReportGenerator();
         signUpsGenerator.setBridgeHelper(mockBridgeHelper);
         
+        RetentionReportGenerator retentionGenerator = new RetentionReportGenerator();
+        retentionGenerator.setBridgeHelper(mockBridgeHelper);
+        
         Map<ReportType, ReportGenerator> generators = new ImmutableMap.Builder<ReportType, ReportGenerator>()
                 .put(ReportType.DAILY, uploadsGenerator).put(ReportType.WEEKLY, uploadsGenerator)
-                .put(ReportType.DAILY_SIGNUPS, signUpsGenerator).build();        
+                .put(ReportType.DAILY_SIGNUPS, signUpsGenerator)
+                .put(ReportType.DAILY_RETENTION, retentionGenerator).build();
         
         // set up callback
         processor = new BridgeReporterProcessor();
@@ -301,5 +308,4 @@ public class BridgeReporterProcessorTest {
         assertTrue(map.containsKey("byStatus"));
         assertTrue(map.containsKey("bySharing"));
     }
-    
 }


### PR DESCRIPTION
SignUpsReportGenerator filters out admin accounts so "roles" needed to be initialized in the participants