### PR TITLE
do not log error if OAuth access grant is not found

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/fitbit/worker/BridgeFitBitWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/fitbit/worker/BridgeFitBitWorkerProcessor.java
@@ -27,6 +27,7 @@ import org.sagebionetworks.bridge.sqs.PollSqsWorkerBadRequestException;
 import org.sagebionetworks.bridge.worker.ThrowingConsumer;
 import org.sagebionetworks.bridge.workerPlatform.bridge.BridgeHelper;
 import org.sagebionetworks.bridge.workerPlatform.bridge.FitBitUser;
+import org.sagebionetworks.bridge.workerPlatform.exceptions.FitBitUserNotConfiguredException;
 import org.sagebionetworks.bridge.workerPlatform.exceptions.WorkerException;
 import org.sagebionetworks.bridge.workerPlatform.util.JsonUtils;
 
@@ -207,7 +208,11 @@ public class BridgeFitBitWorkerProcessor implements ThrowingConsumer<JsonNode> {
                         }
                     }
                 } catch (Exception ex) {
-                    LOG.error("Error getting next user: " + ex.getMessage(), ex);
+                    if (ex instanceof FitBitUserNotConfiguredException) {
+                        LOG.info("User not configured for FitBit: " + ex.getMessage(), ex);
+                    } else {
+                        LOG.error("Error getting next user: " + ex.getMessage(), ex);
+                    }
 
                     // The Iterator is a paginated iterator that calls Bridge for each user. If for some reason, it
                     // keeps throwing exceptions (for example, Bridge is down), this could retry infinitely. Cap the

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/exceptions/FitBitUserNotConfiguredException.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/exceptions/FitBitUserNotConfiguredException.java
@@ -1,0 +1,24 @@
+package org.sagebionetworks.bridge.workerPlatform.exceptions;
+
+/**
+ * This exception is specific to the FitBitUserIterator. It is a runtime exception because iterators can't throw
+ * exceptions. This indicates that the user is not configured for FitBit, so we can handle this case differently than
+ * an unexpected error.
+ */
+@SuppressWarnings("serial")
+public class FitBitUserNotConfiguredException extends RuntimeException {
+    public FitBitUserNotConfiguredException() {
+    }
+
+    public FitBitUserNotConfiguredException(String message) {
+        super(message);
+    }
+
+    public FitBitUserNotConfiguredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FitBitUserNotConfiguredException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/bridge/FitBitUserIteratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/bridge/FitBitUserIteratorTest.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.rest.model.ForwardCursorStringList;
 import org.sagebionetworks.bridge.rest.model.OAuthAccessToken;
+import org.sagebionetworks.bridge.workerPlatform.exceptions.FitBitUserNotConfiguredException;
 import org.sagebionetworks.bridge.workerPlatform.util.Constants;
 
 @SuppressWarnings("unchecked")
@@ -217,7 +218,11 @@ public class FitBitUserIteratorTest {
             iter.next();
             fail("expected exception");
         } catch (RuntimeException ex) {
-            // expected exception
+            if (skipsErrorUser) {
+                assertTrue(ex instanceof FitBitUserNotConfiguredException);
+            } else {
+                assertFalse(ex instanceof FitBitUserNotConfiguredException);
+            }
         }
         if (!skipsErrorUser) {
             FitBitUser user1 = iter.next();


### PR DESCRIPTION
"OAuth Access Grant not found" is not really an error case. It frequently happens if the user revokes FitBit access, and Bridge Server automatically removes it from Dynamo.

As such, we no longer want to log an error when this happens.