### PR TITLE
propagate UserDataDownload SynapseUnavailableException

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/DefaultTableTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/DefaultTableTask.java
@@ -39,7 +39,7 @@ public class DefaultTableTask extends SynapseDownloadFromTableTask {
                     studyId + " no longer exists");
         } catch (SynapseException ex) {
             throw new AsyncTaskExecutionException("Error verifying synapse table " + synapseTableId +
-                    " for default schema for study " + studyId);
+                    " for default schema for study " + studyId + ": " + ex.getMessage(), ex);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SchemaBasedTableTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SchemaBasedTableTask.java
@@ -52,7 +52,7 @@ public class SchemaBasedTableTask extends SynapseDownloadFromTableTask {
                     schemaKey.toString() + " no longer exists");
         } catch (SynapseException ex) {
             throw new AsyncTaskExecutionException("Error verifying synapse table " + synapseTableId + " for schema " +
-                    schemaKey.toString());
+                    schemaKey.toString() + ": " + ex.getMessage(), ex);
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/DefaultTableTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/DefaultTableTaskTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -13,7 +14,6 @@ import java.util.Set;
 
 import org.joda.time.LocalDate;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -94,7 +94,8 @@ public class DefaultTableTaskTest {
     @Test
     public void errorVerifyingTable() throws Exception {
         // Mock getTable()
-        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(UnknownSynapseServerException.class);
+        TestSynapseException originalEx = new TestSynapseException("test exception");
+        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(originalEx);
 
         // Execute (throws exception).
         try {
@@ -102,7 +103,8 @@ public class DefaultTableTaskTest {
             fail("expected exception");
         } catch (AsyncTaskExecutionException ex) {
             assertEquals(ex.getMessage(), "Error verifying synapse table " + TABLE_ID +
-                    " for default schema for study " + STUDY_ID);
+                    " for default schema for study " + STUDY_ID + ": test exception");
+            assertSame(ex.getCause(), originalEx);
         }
 
         // Verify we _didn't_ delete the table mapping.

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SchemaBasedTableTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SchemaBasedTableTaskTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -13,7 +14,6 @@ import java.util.Set;
 
 import org.joda.time.LocalDate;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -116,7 +116,8 @@ public class SchemaBasedTableTaskTest {
     @Test
     public void errorVerifyingTable() throws Exception {
         // Mock getTable()
-        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(UnknownSynapseServerException.class);
+        TestSynapseException originalEx = new TestSynapseException("test exception");
+        when(mockSynapseHelper.getTable(TABLE_ID)).thenThrow(originalEx);
 
         // Execute (throws exception).
         try {
@@ -124,7 +125,8 @@ public class SchemaBasedTableTaskTest {
             fail("expected exception");
         } catch (AsyncTaskExecutionException ex) {
             assertEquals(ex.getMessage(), "Error verifying synapse table " + TABLE_ID + " for schema " +
-                    SCHEMA_KEY.toString());
+                    SCHEMA_KEY.toString() + ": test exception");
+            assertSame(ex.getCause(), originalEx);
         }
 
         // Verify we _didn't_ delete the table mapping.


### PR DESCRIPTION
We were unintentionally swallowing the SynapseUnavailableException, so the worker didn't know to short circuit when Synapse was in READ_ONLY mode.