### PR TITLE
Can send SMS reminders w/o activities

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessor.java
@@ -370,12 +370,6 @@ public class BridgeNotificationWorkerProcessor implements ThrowingConsumer<JsonN
         Iterator<ScheduledActivity> activityIterator = bridgeHelper.getTaskHistory(studyId, userId, taskId,
                 activityRangeStart, activityRangeEnd);
 
-        // If the user somehow has no activities with this task ID, don't notify the user. The account is probably not
-        // fully bootstrapped, and we should avoid sending them a notification.
-        if (!activityIterator.hasNext()) {
-            return null;
-        }
-
         // Map the events by scheduled date so it's easier to work with.
         Map<LocalDate, ScheduledActivity> activitiesByDate = new HashMap<>();
         while (activityIterator.hasNext()) {

--- a/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/worker/BridgeNotificationWorkerProcessorProcessAccountTest.java
@@ -37,7 +37,6 @@ import org.sagebionetworks.bridge.rest.model.UserConsentHistory;
 import org.sagebionetworks.bridge.workerPlatform.bridge.BridgeHelper;
 import org.sagebionetworks.bridge.workerPlatform.dynamodb.DynamoHelper;
 
-@SuppressWarnings("JavaReflectionMemberAccess")
 public class BridgeNotificationWorkerProcessorProcessAccountTest {
     private static final String CLINICAL_CONSENT_GROUP = "clinical_consent";
     private static final String EVENT_ID_ENROLLMENT = "enrollment";
@@ -268,14 +267,6 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
         verifyNoNotification();
     }
 
-    // branch coverage
-    @Test
-    public void noActivities() throws Exception {
-        activityList.clear();
-        processor.processAccountForDate(STUDY_ID, TEST_DATE, USER_ID);
-        verifyNoNotification();
-    }
-
     @Test
     public void didTodaysActivities() throws Exception {
         // Today is enrollment + 3. Do that activity.
@@ -341,6 +332,16 @@ public class BridgeNotificationWorkerProcessorProcessAccountTest {
     public void didNoActivities() throws Exception {
         // This is the "base case" for our tests. Since the majority of our tests do no send notifications, we wanted
         // the basic configuration to send a notification, to help ensure that our tests are working properly.
+        processor.processAccountForDate(STUDY_ID, TEST_DATE, USER_ID);
+        verifySentNotification(NotificationType.EARLY, MESSAGE_EARLY);
+    }
+
+    @Test
+    public void noActivities() throws Exception {
+        // User for whatever reason has no activity events on the server. This could happen if, for example, the user
+        // did not engage with the last 2 study bursts. If this happens, we should still act like the user has
+        // activities, and they were simply not completed.
+        activityList.clear();
         processor.processAccountForDate(STUDY_ID, TEST_DATE, USER_ID);
         verifySentNotification(NotificationType.EARLY, MESSAGE_EARLY);
     }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2793

Turned out to be simpler than I imagined. As it turns out, the code already has the null-checks to protect against missing activities. I just also had a check to not run if there were no activities.