### PR TITLE
Don't throw when we fail to parse Engagement report

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/notification/helper/TemplateVariableHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/notification/helper/TemplateVariableHelper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.google.gson.JsonSyntaxException;
 import com.jcabi.aspects.Cacheable;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
@@ -110,7 +111,16 @@ public class TemplateVariableHelper {
         if (obj == null) {
             return null;
         }
-        obj = RestUtils.toType(obj, Map.class);
+        try {
+            obj = RestUtils.toType(obj, Map.class);
+        } catch (JsonSyntaxException ex) {
+            // The format for the Engagement report has changed since launch and is currently unclear. In some cases,
+            // the format is not parsable by the old code. If this happens, log a warning and return null instead of
+            // crashing.
+            // See https://sagebionetworks.jira.com/browse/MP2-299
+            LOG.warn("Error parsing Engagement report: " + ex.getMessage(), ex);
+            return null;
+        }
 
         // Recursive descent on the map.
         for (String oneKey : keys) {

--- a/src/test/java/org/sagebionetworks/bridge/notification/helper/TemplateVariableHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/notification/helper/TemplateVariableHelperTest.java
@@ -147,6 +147,18 @@ public class TemplateVariableHelperTest {
 
     // branch coverage
     @Test
+    public void studyCommitment_notJsonObject() throws Exception {
+        String reportDataJson = "not-object";
+        Object reportDataObj = RestUtils.GSON.fromJson(reportDataJson, String.class);
+        engagementReport.setData(reportDataObj);
+
+        // Execute test.
+        String result = templateVariableHelper.getStudyCommitmentUncached(APP_ID, userId);
+        assertNull(result);
+    }
+
+    // branch coverage
+    @Test
     public void studyCommitment_noClientData() throws Exception {
         // By default, engagement report contains no client data.
 


### PR DESCRIPTION
This causes us to not send the pre-burst notification when we fail to parse the Engagement report. This adds a simple try-catch so we can return null and fall back to the default message.