### PR TITLE
Shift the sleep to the outer loop which we’re hitting repeatedly without executing the inner loop.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/adherence/WeeklyAdherenceReportWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/adherence/WeeklyAdherenceReportWorkerProcessor.java
@@ -146,9 +146,11 @@ public class WeeklyAdherenceReportWorkerProcessor implements ThrowingConsumer<Js
                         recordOutOfCompliance(userAdherencePercent, studyThresholdPercent,
                                 app.getIdentifier(), studyId, summary.getId());
                     }
-                    // Slight pause between requests
-                    Thread.sleep(THREAD_SLEEP_INTERVAL);
+                    // sleeping between studies isn't needed at this point as the vast majority of 
+                    // accounts are only enrolled in one study.
                 }
+                // Slight pause between processing of accounts
+                Thread.sleep(THREAD_SLEEP_INTERVAL);
             }
             LOG.info("Weekly adherence report caching for app " + app.getIdentifier() + " took "
                     + appStopwatch.elapsed(TimeUnit.SECONDS) + " seconds");


### PR DESCRIPTION
In executing against production, the mtg-alpha app has a mix of legacy and other studies (so we process it) and yet, tens of thousands of the accounts are in a legacy study. In this case, the code is executing the outer processing loop but not the inner loop, so it's not pausing, it's executing a request for a page of account records without a pause (thousands of them).

Moved the sleep to the outer loop to avoid this. The inner loop (through an account's studies) will rarely loop over multiple studies because accounts are almost never enrolled in multiple studies today.

I'm hoping this will improve the apdex score of the next run of the reporter.