### PR TITLE
Use the flag to skip over accounts that have never signed in to Bridge.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.23.25</version>
+            <version>0.23.26</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.23.20</version>
+            <version>0.23.25</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/adherence/WeeklyAdherenceReportWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/adherence/WeeklyAdherenceReportWorkerProcessor.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.adherence;
 
+import static java.lang.Boolean.TRUE;
 import static org.sagebionetworks.bridge.rest.model.EnrollmentFilter.ENROLLED;
 import static org.sagebionetworks.bridge.rest.model.StudyPhase.DESIGN;
 import static org.sagebionetworks.bridge.rest.model.StudyPhase.IN_FLIGHT;
@@ -14,7 +15,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.joda.time.DateTime;
-import org.sagebionetworks.bridge.exporter3.Ex3ParticipantVersionRequest;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 import org.sagebionetworks.bridge.rest.ClientManager;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
@@ -35,7 +35,6 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 @Component("WeeklyAdherenceReportWorker")
@@ -123,7 +122,8 @@ public class WeeklyAdherenceReportWorkerProcessor implements ThrowingConsumer<Js
             
             // Now go through all accounts that are enrolled in at least one study and push cache a report for each study.
             PagedResourceIterator<AccountSummary> acctIterator = new PagedResourceIterator<>((ob, ps) -> {
-                AccountSummarySearch search = new AccountSummarySearch().offsetBy(ob).pageSize(ps).enrollment(ENROLLED);
+                AccountSummarySearch search = new AccountSummarySearch().offsetBy(ob).pageSize(ps)
+                        .enrollment(ENROLLED).inUse(TRUE);
                 return workersApi.searchAccountSummariesForApp(app.getIdentifier(), search).execute().body().getItems();
             }, PAGE_SIZE);
             

--- a/src/test/java/org/sagebionetworks/bridge/adherence/WeeklyAdherenceReportWorkerProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/adherence/WeeklyAdherenceReportWorkerProcessorTest.java
@@ -168,6 +168,7 @@ public class WeeklyAdherenceReportWorkerProcessorTest extends Mockito {
         
         AccountSummarySearch search = searchCaptor.getAllValues().get(0);
         assertEquals(search.getEnrollment(), EnrollmentFilter.ENROLLED);
+        assertEquals(search.isInUse(), Boolean.TRUE);
         assertEquals(search.getOffsetBy(), Integer.valueOf(0));
         assertEquals(search.getPageSize(), Integer.valueOf(PAGE_SIZE));
         


### PR DESCRIPTION
Ran the integration tests and verified that it is skipping over withdrawn and unused accounts that are in my local study1.