### PR TITLE
BRIDGE-3150 Backfill Participant Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.25.4</version>
+            <version>0.25.9</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsRequest.java
@@ -1,0 +1,25 @@
+package org.sagebionetworks.bridge.exporter3;
+
+/** A request to backfill participant versions. */
+public class BackfillParticipantVersionsRequest {
+    private String appId;
+    private String s3Key;
+
+    /** App ID of participants to backfill. */
+    public String getAppId() {
+        return appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    /** S3 key in the backfill bucket. In this file is a list of healthcodes to backfill. */
+    public String getS3Key() {
+        return s3Key;
+    }
+
+    public void setS3Key(String s3Key) {
+        this.s3Key = s3Key;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsWorkerProcessor.java
@@ -1,0 +1,126 @@
+package org.sagebionetworks.bridge.exporter3;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Stopwatch;
+import com.google.common.util.concurrent.RateLimiter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.sqs.PollSqsWorkerBadRequestException;
+import org.sagebionetworks.bridge.worker.ThrowingConsumer;
+import org.sagebionetworks.bridge.workerPlatform.bridge.BridgeHelper;
+import org.sagebionetworks.bridge.workerPlatform.dynamodb.DynamoHelper;
+
+/**
+ * This worker takes a list of participants and calls the Backfill Participant Version API on Bridge Server, which both
+ * creates the Participant Version and exports it to Synapse. The use case for this worker is if the participant
+ * version doesn't exist at all for a participant and needs to be created. This can happen if the participant predates
+ * the Participant Versions feature, or if the Synapse project wasn’t initialized until after the participant was
+ * enrolled and already started submitting health data.
+ */
+@Component("BackfillParticipantVersionsWorker")
+public class BackfillParticipantVersionsWorkerProcessor implements ThrowingConsumer<JsonNode> {
+    private static final Logger LOG = LoggerFactory.getLogger(BackfillParticipantVersionsWorkerProcessor.class);
+
+    // If there are a lot of health codes, write log messages regularly so we know the worker is still running.
+    private static final int REPORTING_INTERVAL = 1000;
+
+    static final String CONFIG_KEY_BACKFILL_BUCKET = "backfill.bucket";
+    static final String WORKER_ID = "BackfillParticipantVersionsWorker";
+
+    // Rate limiter. We accept this many health codes per second. Since Synapse throttles at 10 requests per second,
+    // so there's no point in going faster than that.
+    private final RateLimiter rateLimiter = RateLimiter.create(10.0);
+
+    private String backfillBucket;
+    private BridgeHelper bridgeHelper;
+    private DynamoHelper dynamoHelper;
+    private S3Helper s3Helper;
+
+    @Autowired
+    public final void setConfig(Config config) {
+        this.backfillBucket = config.get(CONFIG_KEY_BACKFILL_BUCKET);
+    }
+
+    @Autowired
+    public final void setBridgeHelper(BridgeHelper bridgeHelper) {
+        this.bridgeHelper = bridgeHelper;
+    }
+
+    @Autowired
+    public final void setDynamoHelper(DynamoHelper dynamoHelper) {
+        this.dynamoHelper = dynamoHelper;
+    }
+
+    @Autowired
+    public final void setS3Helper(S3Helper s3Helper) {
+        this.s3Helper = s3Helper;
+    }
+
+    @Override
+    public void accept(JsonNode jsonNode) throws Exception {
+        // Parse request.
+        BackfillParticipantVersionsRequest request;
+        try {
+            request = DefaultObjectMapper.INSTANCE.treeToValue(jsonNode, BackfillParticipantVersionsRequest.class);
+        } catch (IOException e) {
+            throw new PollSqsWorkerBadRequestException("Error parsing request: " + e.getMessage(), e);
+        }
+
+        // Process request.
+        Stopwatch requestStopwatch = Stopwatch.createStarted();
+        try {
+            process(request);
+        } finally {
+            LOG.info("Backfill participant versions request took " + requestStopwatch.elapsed(TimeUnit.SECONDS) +
+                    " seconds for app " + request.getAppId() + " s3 key " + request.getS3Key());
+        }
+    }
+
+    private void process(BackfillParticipantVersionsRequest request) throws IOException {
+        String appId = request.getAppId();
+        String s3Key = request.getS3Key();
+
+        // Get list of health codes from S3.
+        List<String> healthCodeList = s3Helper.readS3FileAsLines(backfillBucket, s3Key);
+        int totalHealthCodes = healthCodeList.size();
+        LOG.info("Starting backfill participant versions for app " + appId + " s3 key " + s3Key + " with " +
+                totalHealthCodes + " health codes");
+
+        // Backfill health codes in a loop.
+        int numHealthCodes = 0;
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        for (String healthCode : healthCodeList) {
+            // Rate limit.
+            rateLimiter.acquire();
+
+            // Backfill.
+            try {
+                bridgeHelper.backfillParticipantVersion(appId, "healthcode:" + healthCode);
+            } catch (Exception ex) {
+                LOG.error("Error backfilling participant version for app " + appId + " health code " + healthCode, ex);
+            }
+
+            // Reporting.
+            numHealthCodes++;
+            if (numHealthCodes % REPORTING_INTERVAL == 0) {
+                LOG.info("Backfilling participant versions for app " + appId + ": " + numHealthCodes +
+                        " health codes out of " + totalHealthCodes + " in " + stopwatch.elapsed(TimeUnit.SECONDS) +
+                        " seconds");
+            }
+        }
+
+        // Write to Worker Log in DDB so we can signal end of processing.
+        String tag = "app=" + appId + ", s3Key=" + s3Key + ", totalHealthCodes=" + totalHealthCodes;
+        dynamoHelper.writeWorkerLog(WORKER_ID, tag);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelper.java
@@ -171,6 +171,11 @@ public class BridgeHelper {
                 reportId, startDate, endDate).execute().body().getItems();
     }
 
+    /** Backfills the participant version for a user in a given app. */
+    public void backfillParticipantVersion(String appId, String userId) throws IOException {
+        clientManager.getClient(ForWorkersApi.class).backfillParticipantVersion(appId, userId).execute();
+    }
+
     /** Gets the participant version for the app and user ID and version number. */
     public ParticipantVersion getParticipantVersion(String appId, String userId, int participantVersion)
             throws IOException {

--- a/src/main/resources/BridgeWorkerPlatform.conf
+++ b/src/main/resources/BridgeWorkerPlatform.conf
@@ -35,6 +35,11 @@ threadpool.general.count = 6
 # more than 3 thread pool workers.
 threadpool.synapse.count = 3
 
+local.backfill.bucket = org-sagebridge-backfill-devlocal
+dev.backfill.bucket = org-sagebridge-backfill-devdevelop
+uat.backfill.bucket = org-sagebridge-backfill-devstaging
+prod.backfill.bucket = org-sagebridge-backfill-prod
+
 local.health.data.bucket.raw = org-sagebridge-rawhealthdata-devlocal
 dev.health.data.bucket.raw = org-sagebridge-rawhealthdata-devdevelop
 uat.health.data.bucket.raw = org-sagebridge-rawhealthdata-devstaging

--- a/src/test/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsRequestTest.java
@@ -1,0 +1,24 @@
+package org.sagebionetworks.bridge.exporter3;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+
+public class BackfillParticipantVersionsRequestTest {
+    @Test
+    public void deserialize() throws Exception {
+        // Start with JSON text.
+        String jsonText = "{\n" +
+                "   \"appId\":\"test-app\",\n" +
+                "   \"s3Key\":\"my-healthcode-list\"\n" +
+                "}";
+
+        // Convert to Java object.
+        BackfillParticipantVersionsRequest request = DefaultObjectMapper.INSTANCE.readValue(jsonText,
+                BackfillParticipantVersionsRequest.class);
+        assertEquals(request.getAppId(), "test-app");
+        assertEquals(request.getS3Key(), "my-healthcode-list");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsWorkerProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter3/BackfillParticipantVersionsWorkerProcessorTest.java
@@ -1,0 +1,76 @@
+package org.sagebionetworks.bridge.exporter3;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.workerPlatform.bridge.BridgeHelper;
+import org.sagebionetworks.bridge.workerPlatform.dynamodb.DynamoHelper;
+
+public class BackfillParticipantVersionsWorkerProcessorTest {
+    private static final String APP_ID = "test-app";
+    private static final String BACKFILL_BUCKET = "my-backfill-bucket";
+    private static final String HEALTH_CODE_ERROR = "health-code-with-error";
+    private static final String HEALTH_CODE_SUCCESS = "health-code-that-succeeds";
+    private static final String S3KEY = "my-healthcode-list";
+
+    @Mock
+    private BridgeHelper mockBridgeHelper;
+
+    @Mock
+    private DynamoHelper mockDynamoHelper;
+
+    @Mock
+    private S3Helper mockS3Helper;
+
+    @InjectMocks
+    private BackfillParticipantVersionsWorkerProcessor processor;
+
+    @BeforeMethod
+    public void beforeMethod() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        // Mock config.
+        Config mockConfig = mock(Config.class);
+        when(mockConfig.get(BackfillParticipantVersionsWorkerProcessor.CONFIG_KEY_BACKFILL_BUCKET)).thenReturn(
+                BACKFILL_BUCKET);
+        processor.setConfig(mockConfig);
+    }
+
+    @Test
+    public void test() throws Exception {
+        // Set up mocks.
+        when(mockS3Helper.readS3FileAsLines(BACKFILL_BUCKET, S3KEY)).thenReturn(ImmutableList.of(HEALTH_CODE_ERROR,
+                HEALTH_CODE_SUCCESS));
+        doThrow(BridgeSDKException.class).when(mockBridgeHelper).backfillParticipantVersion(APP_ID,
+                "healthcode:" + HEALTH_CODE_ERROR);
+
+        // Set up input.
+        BackfillParticipantVersionsRequest request = new BackfillParticipantVersionsRequest();
+        request.setAppId(APP_ID);
+        request.setS3Key(S3KEY);
+        JsonNode requestNode = DefaultObjectMapper.INSTANCE.convertValue(request, JsonNode.class);
+
+        // Execute and verify.
+        processor.accept(requestNode);
+        verify(mockBridgeHelper).backfillParticipantVersion(APP_ID, "healthcode:" + HEALTH_CODE_ERROR);
+        verify(mockBridgeHelper).backfillParticipantVersion(APP_ID, "healthcode:" + HEALTH_CODE_SUCCESS);
+        verify(mockDynamoHelper).writeWorkerLog(eq(BackfillParticipantVersionsWorkerProcessor.WORKER_ID),
+                notNull(String.class));
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelperTest.java
@@ -424,6 +424,17 @@ public class BridgeHelperTest {
     }
 
     @Test
+    public void backfillParticipantVersion() throws Exception {
+        // Set up mocks.
+        Call<Message> mockCall = mock(Call.class);
+        when(mockWorkerApi.backfillParticipantVersion(APP_ID, USER_ID)).thenReturn(mockCall);
+
+        // Execute and validate.
+        bridgeHelper.backfillParticipantVersion(APP_ID, USER_ID);
+        verify(mockWorkerApi).backfillParticipantVersion(APP_ID, USER_ID);
+    }
+
+    @Test
     public void getParticipantVersion() throws Exception {
         // Set up mocks.
         ParticipantVersion participantVersion = new ParticipantVersion();


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3150

Backfill Participant Worker. If you have participants without a participant versions, but should, this worker will force creation of new participant versions. (Does nothing if the participant version already exists, or if Exporter 3.0 is not enabled.)

Requires https://github.com/Sage-Bionetworks/BridgeServer2/pull/608