### PR TITLE
Add logging to Ex3 workers

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter3/Ex3ParticipantVersionWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter3/Ex3ParticipantVersionWorkerProcessor.java
@@ -68,6 +68,11 @@ public class Ex3ParticipantVersionWorkerProcessor implements ThrowingConsumer<Js
         Stopwatch requestStopwatch = Stopwatch.createStarted();
         try {
             process(request);
+        } catch (Exception ex) {
+            // Catch and rethrow exception. The extra logging statement makes it easier to do log analysis.
+            LOG.error("Exception thrown for participant version request for app " + request.getAppId() +
+                    " healthcode " + request.getHealthCode() + " version " + request.getParticipantVersion(), ex);
+            throw ex;
         } finally {
             LOG.info("Participant version export request took " + requestStopwatch.elapsed(TimeUnit.SECONDS) + " seconds for app " +
                     request.getAppId() + " healthcode " + request.getHealthCode() + " version " +

--- a/src/main/java/org/sagebionetworks/bridge/exporter3/Exporter3WorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter3/Exporter3WorkerProcessor.java
@@ -148,6 +148,11 @@ public class Exporter3WorkerProcessor implements ThrowingConsumer<JsonNode> {
         Stopwatch requestStopwatch = Stopwatch.createStarted();
         try {
             process(request);
+        } catch (Exception ex) {
+            // Catch and rethrow exception. The extra logging statement makes it easier to do log analysis.
+            LOG.error("Exception thrown for export request for app " + request.getAppId() + " record " +
+                    request.getRecordId(), ex);
+            throw ex;
         } finally {
             LOG.info("Export request took " + requestStopwatch.elapsed(TimeUnit.SECONDS) + " seconds for app " +
                     request.getAppId() + " record " + request.getRecordId());


### PR DESCRIPTION
Right now, if Exporter3Worker or Ex3ParticipantVersionWorker throws, the exception will be bubbled up all the way to PollSqsWorker, and we lose the context about which app and upload (or participant version) the request was for.

This can be worked around by reading the lines around the log error, which is fine when there are only a few errors in the log. However, when there are a lot of errors in the log, it's a lot more helpful to have the context information in the log error itself.

This adds a catch, which logs the error message, and then re-throws the same exception. (According to Stack Overflow, this preserves the stack trace.) It has a side effect that all the errors will be logged twice, but this shouldn't be an issue. Worst case scenario, we may just need to double our error alarm threshold.