### PR TITLE
Move S3EventNotificationCallback from Exporter to Worker

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/uploadcomplete/S3EventNotificationCallback.java
+++ b/src/main/java/org/sagebionetworks/bridge/uploadcomplete/S3EventNotificationCallback.java
@@ -1,0 +1,120 @@
+package org.sagebionetworks.bridge.uploadcomplete;
+
+import java.util.List;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.sqs.PollSqsCallback;
+import org.sagebionetworks.bridge.workerPlatform.bridge.BridgeHelper;
+
+@Component
+public class S3EventNotificationCallback implements PollSqsCallback {
+    private static final Logger LOG = LoggerFactory.getLogger(S3EventNotificationCallback.class);
+
+    static final String CONFIG_KEY_UPLOAD_BUCKET = "upload.bucket";
+    private static final String S3_EVENT_SOURCE = "aws:s3";
+    private static final String S3_OBJECT_CREATED_EVENT_PREFIX = "ObjectCreated:";
+
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper();
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private BridgeHelper bridgeHelper;
+    private String uploadBucket;
+
+    /** Bridge helper, used to call Bridge Server to complete the upload. */
+    @Autowired
+    public final void setBridgeHelper(BridgeHelper bridgeHelper) {
+        this.bridgeHelper = bridgeHelper;
+    }
+
+    /** Bridge Config. */
+    @Autowired
+    public final void setConfig(Config config) {
+        uploadBucket = config.get(CONFIG_KEY_UPLOAD_BUCKET);
+    }
+
+    @Override
+    public void callback(String messageBody) {
+        S3EventNotification notification;
+        try {
+            notification = OBJECT_MAPPER.readValue(messageBody, S3EventNotification.class);
+        } catch (JsonProcessingException ex) {
+            // Malformed S3 notification. Log a warning and squelch.
+            LOG.warn("S3 notification is malformed: " + messageBody);
+            return;
+        }
+        if (notification == null) {
+            // Null S3 notification. Log a warning and squelch.
+            LOG.warn("S3 notification is null: " + messageBody);
+            return;
+        }
+        List<S3EventNotification.S3EventNotificationRecord> recordList = notification.getRecords();
+        if (recordList == null || recordList.isEmpty()) {
+            // Notification w/o record list is not actionable. Log a warning and squelch.
+            LOG.warn("S3 notification without record list: " + messageBody);
+            return;
+        }
+
+        callback(notification);
+    }
+
+    // package-scoped to enable mocking/testing
+    void callback(S3EventNotification notification) {
+        notification.getRecords().stream().filter(this::shouldProcessRecord).forEach(record -> {
+            S3EventNotification.S3Entity s3Object = record.getS3();
+            String bucket = s3Object.getBucket().getName();
+
+            // S3EventNotification shares the SNS topic with the Virus Scan, because a bucket can only have one
+            // notification configured. However, the Virus Scan is configured for many buckets, and S3EventNotification
+            // only cares about upload. Skip all non-upload buckets.
+            if (bucket == null || !bucket.equals(uploadBucket)) {
+                LOG.info("Skipping bucket " + bucket);
+                return;
+            }
+
+            String uploadId = record.getS3().getObject().getKey();
+            try {
+                bridgeHelper.completeUpload(uploadId);
+                LOG.info("Completed upload, id=" + uploadId);
+            } catch (BridgeSDKException ex) {
+                String errorMsg = "Error completing upload id " + uploadId + ": " + ex.getMessage();
+                int status = ex.getStatusCode();
+                if (status == 400 || 404 <= status && status <= 499) {
+                    // HTTP 4XX means bad request (such as 404 not found). This can happen for a variety of reasons and
+                    // is generally not developer actionable. Log a warning and swallow the exception. This way, the
+                    // SQS poll worker will succeed the callback and delete the message, preventing spurious retries.
+                    //
+                    // We should still retry 401s and 403s because these indicate problems with our client and not
+                    // problems with the session.
+                    LOG.warn(errorMsg, ex);
+                } else {
+                    // A non-4XX error generally means a server error. We'll want to retry this. Log an error and
+                    // re-throw.
+                    LOG.error(errorMsg, ex);
+
+                    // Foreach handlers can't throw checked exceptions. It's not worth creating an unchecked exception
+                    // given that we're about to refactor error handling. For now, just throw a RuntimeException.
+                    throw new RuntimeException(errorMsg, ex);
+                }
+            }
+        });
+    }
+
+    // package-scoped to enable mocking/testing
+    boolean shouldProcessRecord(S3EventNotification.S3EventNotificationRecord record) {
+        return S3_EVENT_SOURCE.equals(record.getEventSource()) && record.getEventName().startsWith(S3_OBJECT_CREATED_EVENT_PREFIX);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelper.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
 import org.sagebionetworks.bridge.rest.model.ExportToAppNotification;
 import org.sagebionetworks.bridge.rest.model.HealthDataRecordEx3;
@@ -258,6 +260,22 @@ public class BridgeHelper {
     public Iterator<ScheduledActivity> getTaskHistory(String appId, String userId, String taskId,
             DateTime scheduledOnStart, DateTime scheduledOnEnd) {
         return new TaskHistoryIterator(clientManager, appId, userId, taskId, scheduledOnStart, scheduledOnEnd);
+    }
+
+    /**
+     * Signals Bridge Server that the upload is completed and to begin processing the upload. Used by Upload
+     * Auto-Complete.
+     *
+     * @param uploadId
+     *         upload to mark completed and begin processing
+     */
+    public void completeUpload(String uploadId) {
+        try {
+            clientManager.getClient(ForWorkersApi.class).completeUploadSession(uploadId, null, null)
+                    .execute();
+        } catch (IOException ex) {
+            throw new BridgeSDKException("Error completing upload to Bridge: " + ex.getMessage(), ex);
+        }
     }
 
     /*

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/SpringConfig.java
@@ -58,6 +58,7 @@ import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 import org.sagebionetworks.bridge.sqs.SqsHelper;
 import org.sagebionetworks.bridge.synapse.SynapseHelper;
 import org.sagebionetworks.bridge.udd.worker.BridgeUddProcessor;
+import org.sagebionetworks.bridge.uploadcomplete.S3EventNotificationCallback;
 import org.sagebionetworks.bridge.worker.ThrowingConsumer;
 import org.sagebionetworks.bridge.workerPlatform.multiplexer.BridgeWorkerPlatformSqsCallback;
 import org.sagebionetworks.bridge.workerPlatform.util.Constants;
@@ -226,15 +227,29 @@ public class SpringConfig {
         return sqsHelper;
     }
 
-    @Bean
+    @Bean(name = "generalSqsWorker")
     @Autowired
-    public PollSqsWorker sqsWorker(BridgeWorkerPlatformSqsCallback callback) {
+    public PollSqsWorker generalSqsWorker(BridgeWorkerPlatformSqsCallback callback) {
         Config config = bridgeConfig();
 
         PollSqsWorker sqsWorker = new PollSqsWorker();
         sqsWorker.setCallback(callback);
         sqsWorker.setExecutorService(generalExecutorService());
         sqsWorker.setQueueUrl(config.get("workerPlatform.request.sqs.queue.url"));
+        sqsWorker.setSleepTimeMillis(config.getInt("workerPlatform.request.sqs.sleep.time.millis"));
+        sqsWorker.setSqsHelper(sqsHelper());
+        return sqsWorker;
+    }
+
+    @Bean(name = "s3NotificationSqsWorker")
+    @Autowired
+    public PollSqsWorker s3NotificationSqsWorker(S3EventNotificationCallback s3NotificationCallback) {
+        Config config = bridgeConfig();
+
+        PollSqsWorker sqsWorker = new PollSqsWorker();
+        sqsWorker.setCallback(s3NotificationCallback);
+        sqsWorker.setExecutorService(generalExecutorService());
+        sqsWorker.setQueueUrl(config.get("s3.notification.sqs.queue.url"));
         sqsWorker.setSleepTimeMillis(config.getInt("workerPlatform.request.sqs.sleep.time.millis"));
         sqsWorker.setSqsHelper(sqsHelper());
         return sqsWorker;

--- a/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/WorkerLauncher.java
+++ b/src/main/java/org/sagebionetworks/bridge/workerPlatform/config/WorkerLauncher.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.workerPlatform.config;
 
+import java.util.Map;
+
 import org.sagebionetworks.bridge.heartbeat.HeartbeatLogger;
 import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 import org.slf4j.Logger;
@@ -17,7 +19,7 @@ public class WorkerLauncher implements CommandLineRunner {
     private static final Logger LOG = LoggerFactory.getLogger(WorkerLauncher.class);
 
     private HeartbeatLogger heartbeatLogger;
-    private PollSqsWorker pollSqsWorkers;
+    private Map<String, PollSqsWorker> pollSqsWorkers;
 
     @Autowired
     public final void setHeartbeatLogger(HeartbeatLogger heartbeatLogger) {
@@ -25,7 +27,7 @@ public class WorkerLauncher implements CommandLineRunner {
     }
 
     @Autowired
-    public final void setPollSqsWorkers(PollSqsWorker pollSqsWorkers) {
+    public final void setPollSqsWorkers(Map<String, PollSqsWorker> pollSqsWorkers) {
         this.pollSqsWorkers = pollSqsWorkers;
     }
 
@@ -40,7 +42,9 @@ public class WorkerLauncher implements CommandLineRunner {
         LOG.info("Worker Platform Starting heartbeat...");
         new Thread(heartbeatLogger).start();
 
-        LOG.info("Worker Platform Starting poll SQS worker...");
-        new Thread(pollSqsWorkers).start();
+        for (Map.Entry<String, PollSqsWorker> entry : pollSqsWorkers.entrySet()) {
+            LOG.info("Worker Platform Starting " + entry.getKey() + "...");
+            new Thread(entry.getValue()).start();
+        }
     }
 }

--- a/src/main/resources/BridgeWorkerPlatform.conf
+++ b/src/main/resources/BridgeWorkerPlatform.conf
@@ -27,9 +27,7 @@ prod.team.bridge.admin = 3388392
 prod.team.bridge.staff = 3388391
 
 # This is used by the SQS listener thread as well as the redrive worker.
-# Currently, the redrive worker uses the general threadpool. Synchronous upload complete takes ~5 seconds, so we'll
-# have 6 threads to make sure we're probabilistically never blocked on thread pools.
-threadpool.general.count = 6
+threadpool.general.count = 12
 
 # You're only allowed 3 concurrent Synapse connections at a time. As such, there's no point in having
 # more than 3 thread pool workers.
@@ -76,6 +74,11 @@ local.userdata.bucket = org-sagebridge-userdata-local
 dev.userdata.bucket = org-sagebridge-userdata-develop
 uat.userdata.bucket = org-sagebridge-userdata-uat
 prod.userdata.bucket = org-sagebridge-userdata-prod
+
+local.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-UploadComplete-Notification-local
+dev.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-UploadComplete-Notification-develop
+uat.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/420786776710/Bridge-UploadComplete-Notification-staging
+prod.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UploadComplete-Notification-prod
 
 local.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
 dev.workerPlatform.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-dev

--- a/src/test/java/org/sagebionetworks/bridge/uploadcomplete/S3EventNotificationCallbackTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/uploadcomplete/S3EventNotificationCallbackTest.java
@@ -1,0 +1,248 @@
+package org.sagebionetworks.bridge.uploadcomplete;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.amazonaws.services.s3.event.S3EventNotification;
+import com.google.common.collect.Lists;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.workerPlatform.bridge.BridgeHelper;
+
+public class S3EventNotificationCallbackTest {
+    private static final String UPLOAD_BUCKET = "org-sagebridge-upload-uat";
+    private static final String UPLOAD_COMPLETE_MESSAGE=
+            "{\"Records\":[{\"eventVersion\":\"2.0\",\"eventSource\":\"aws:s3\"," +
+            "\"awsRegion\":\"us-east-1\"," +
+            "\"eventTime\":\"2016-07-12T22:06:54.454Z\",\"eventName\":\"ObjectCreated:Put\"," +
+            "\"userIdentity\":{\"principalId\":\"AWS:AIDAJCSQZ35H7B4BFOVAW\"},\"requestParameters\":{\"sourceIPAddress\":\"54.87.180" +
+            ".29\"},\"responseElements\":{\"x-amz-request-id\":\"006B5645F94646A3\"," +
+            "\"x-amz-id-2\":\"wk7j6of4ftpRy+lbjt4olcNqp8S2s9d7XUbdOv4UEDh7B+8myhMe45xBEZPUP4+5oxwY9r2z9Yw=\"}," +
+            "\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"Bridge Upload Complete Notification UAT\"," +
+            "\"bucket\":{\"name\":\"org-sagebridge-upload-uat\",\"ownerIdentity\":{\"principalId\":\"AZ9HQM5UC903F\"}," +
+            "\"arn\":\"arn:aws:s3:::org-sagebridge-upload-uat\"},\"object\":{\"key\":\"89b40dab-4982-4d5c-ae21-d74b072d02cd\"," +
+            "\"size\":1488,\"eTag\":\"e40df5cfa5874ab353947eb48ec0cfa4\",\"sequencer\":\"00578569FE6792370C\"}}}]}";
+    private static final String UPLOAD_ID = "89b40dab-4982-4d5c-ae21-d74b072d02cd";
+
+    @Mock
+    private BridgeHelper mockBridgeHelper;
+
+    @InjectMocks
+    @Spy
+    private S3EventNotificationCallback callback;
+
+    @BeforeMethod
+    public void before() {
+        // Set up mocks.
+        MockitoAnnotations.initMocks(this);
+
+        // Config needs to be mocked separately.
+        Config mockConfig = mock(Config.class);
+        when(mockConfig.get(S3EventNotificationCallback.CONFIG_KEY_UPLOAD_BUCKET)).thenReturn(UPLOAD_BUCKET);
+        callback.setConfig(mockConfig);
+    }
+
+    @Test
+    public void testCallback_StringMessage() {
+        callback.callback(UPLOAD_COMPLETE_MESSAGE);
+
+        verify(mockBridgeHelper, times(1)).completeUpload(UPLOAD_ID);
+    }
+
+    @Test
+    public void testCallback_MalformedMessage() {
+        callback.callback("malformed \" message");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_BlankMessage() {
+        callback.callback("");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_NullMessage() {
+        callback.callback("null");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_MessageWrongType() {
+        callback.callback("\"wrong type\"");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_NoRecordList() {
+        callback.callback("{}");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_NullRecordList() {
+        callback.callback("{\"Records\":null}");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_RecordListWrongType() {
+        callback.callback("{\"Records\":\"wrong type\"}");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_EmptyList() {
+        callback.callback("{\"Records\":[]}");
+        verify(mockBridgeHelper, never()).completeUpload(anyString());
+    }
+
+    // Exceptions that Upload Autocomplete should propagate (and retry)
+    @DataProvider(name = "propagatedExceptionDataProvider")
+    public Object[][] propagatedExceptionDataProvider() {
+        return new Object[][] {
+                { 401 },
+                { 403 },
+                { 500 },
+        };
+    }
+
+    @Test(dataProvider = "propagatedExceptionDataProvider")
+    public void testCallback_PropagatesExceptions(int status) {
+        doThrow(new BridgeSDKException("test exception", status)).when(mockBridgeHelper).completeUpload(UPLOAD_ID);
+
+        try {
+            callback.callback(UPLOAD_COMPLETE_MESSAGE);
+            fail("expected exception");
+        } catch (RuntimeException ex) {
+            BridgeSDKException innerEx = (BridgeSDKException) ex.getCause();
+            assertEquals(status, innerEx.getStatusCode());
+        }
+    }
+
+    // Exceptions that Upload Autocomplete should suppress (deterministic errors that shouldn't be retried)
+    @DataProvider(name = "suppressedExceptionDataProvider")
+    public Object[][] suppressedExceptionDataProvider() {
+        return new Object[][] {
+                { 400 },
+                { 404 },
+                { 412 },
+        };
+    }
+
+    @Test(dataProvider = "suppressedExceptionDataProvider")
+    public void testCallback_SuppressesExceptions(int status) {
+        doThrow(new BridgeSDKException("test exception", status)).when(mockBridgeHelper).completeUpload(UPLOAD_ID);
+        callback.callback(UPLOAD_COMPLETE_MESSAGE);
+        verify(mockBridgeHelper, times(1)).completeUpload(UPLOAD_ID);
+    }
+
+    @Test
+    public void testCallback_CompleteUploadForShouldProcessRecords() {
+        String key1 = "key1";
+        String key2 = "key2";
+        String key3 = "key3";
+        String key4 = "key4";
+        String key5 = "key5";
+
+        S3EventNotification.S3EventNotificationRecord record1 = createMockRecordWithKey(UPLOAD_BUCKET, key1);
+        S3EventNotification.S3EventNotificationRecord record2 = createMockRecordWithKey(UPLOAD_BUCKET, key2);
+        S3EventNotification.S3EventNotificationRecord record3 = createMockRecordWithKey(UPLOAD_BUCKET, key3);
+        S3EventNotification.S3EventNotificationRecord record4 = createMockRecordWithKey("wrong bucket", key4);
+        S3EventNotification.S3EventNotificationRecord record5 = createMockRecordWithKey(null, key5);
+
+        S3EventNotification notification = mock(S3EventNotification.class);
+        when(notification.getRecords()).thenReturn(Lists.newArrayList(record1, record2, record3, record4, record5));
+
+        doReturn(true).when(callback).shouldProcessRecord(record1);
+        doReturn(false).when(callback).shouldProcessRecord(record2);
+        doReturn(true).when(callback).shouldProcessRecord(record3);
+        doReturn(true).when(callback).shouldProcessRecord(record4);
+        doReturn(true).when(callback).shouldProcessRecord(record5);
+
+        callback.callback(notification);
+
+        verify(mockBridgeHelper, times(1)).completeUpload(key1);
+        verify(mockBridgeHelper, times(1)).completeUpload(key3);
+        verifyNoMoreInteractions(mockBridgeHelper);
+    }
+
+    private S3EventNotification.S3EventNotificationRecord createMockRecordWithKey(String bucket, String key) {
+        S3EventNotification.S3BucketEntity bucketEntity = mock(S3EventNotification.S3BucketEntity.class);
+        when(bucketEntity.getName()).thenReturn(bucket);
+
+        S3EventNotification.S3ObjectEntity object = mock(S3EventNotification.S3ObjectEntity.class);
+        when(object.getKey()).thenReturn(key);
+
+        S3EventNotification.S3Entity entity = mock(S3EventNotification.S3Entity.class);
+        when(entity.getBucket()).thenReturn(bucketEntity);
+        when(entity.getObject()).thenReturn(object);
+
+        S3EventNotification.S3EventNotificationRecord record = mock(S3EventNotification.S3EventNotificationRecord.class);
+        when(record.getS3()).thenReturn(entity);
+
+        return record;
+    }
+
+    @Test
+    public void testShouldProcessRecords_S3Put() {
+        S3EventNotification.S3EventNotificationRecord s3Put = createMockRecord("aws:s3", "ObjectCreated:Put");
+
+        assertTrue(callback.shouldProcessRecord(s3Put));
+    }
+
+    @Test
+    public void testShouldProcessRecords_S3CompleteMultipartUpload() {
+        S3EventNotification.S3EventNotificationRecord s3Put = createMockRecord("aws:s3", "ObjectCreated:CompleteMultipartUpload");
+
+        assertTrue(callback.shouldProcessRecord(s3Put));
+    }
+
+    @Test
+    public void testShouldProcessRecords_S3Post() {
+        S3EventNotification.S3EventNotificationRecord s3Put = createMockRecord("aws:s3", "ObjectCreated:Post");
+
+        assertTrue(callback.shouldProcessRecord(s3Put));
+    }
+
+    @Test
+    public void testShouldProcessRecords_S3Delete() {
+        S3EventNotification.S3EventNotificationRecord s3Delete = createMockRecord("aws:s3", "ObjectRemoved:Delete");
+
+        assertFalse(callback.shouldProcessRecord(s3Delete));
+    }
+
+    @Test
+    public void testShouldProcessRecords_NotS3() {
+        S3EventNotification.S3EventNotificationRecord notS3 = createMockRecord("aws:dynamo", "ObjectRemoved:Delete");
+
+        assertFalse(callback.shouldProcessRecord(notS3));
+    }
+
+    private S3EventNotification.S3EventNotificationRecord createMockRecord(String source, String name) {
+        S3EventNotification.S3EventNotificationRecord record = mock(S3EventNotification.S3EventNotificationRecord.class);
+        when(record.getEventSource()).thenReturn(source);
+        when(record.getEventName()).thenReturn(name);
+
+        return record;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/workerPlatform/bridge/BridgeHelperTest.java
@@ -32,6 +32,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
 import org.sagebionetworks.bridge.rest.model.ExportToAppNotification;
 import org.sagebionetworks.bridge.rest.model.HealthDataRecordEx3;
@@ -631,6 +633,30 @@ public class BridgeHelperTest {
 
         verify(mockWorkerApi).getParticipantTaskHistoryForApp(eq(APP_ID), eq(USER_ID), eq(TASK_ID), eq(SCHEDULED_ON_START),
                 eq(SCHEDULED_ON_END), any(), any());
+    }
+
+    @Test
+    public void completeUpload() throws Exception {
+        // Mock call.
+        Call<UploadValidationStatus> mockCall = mock(Call.class);
+        when(mockWorkerApi.completeUploadSession(UPLOAD_ID, null, null))
+                .thenReturn(mockCall);
+
+        // Execute and verify.
+        bridgeHelper.completeUpload(UPLOAD_ID);
+        verify(mockCall).execute();
+    }
+
+    @Test(expectedExceptions = BridgeSDKException.class)
+    public void completeUpload_IOException() throws Exception {
+        // Mock call.
+        Call<UploadValidationStatus> mockCall = mock(Call.class);
+        when(mockCall.execute()).thenThrow(IOException.class);
+        when(mockWorkerApi.completeUploadSession(UPLOAD_ID, null, null))
+                .thenReturn(mockCall);
+
+        // Execute and verify.
+        bridgeHelper.completeUpload(UPLOAD_ID);
     }
 
     @Test


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2225

This is mostly copied from Exporter 2.0. Two major differences

1. I was wrong about the Antivirus Trigger SNS topic having a different format. Apparently, I just neglected to click a checkbox when I manually set up the subscription. This change reverts the format change.
2. The Antivirus Trigger SNS topic listens to multiple buckets, not just the upload bucket. There is code in here to filter only to the upload bucket.