### PR TITLE
[DevOps] Exporter 3.0 log with study name in addition to study ID

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter3/Ex3ParticipantVersionWorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter3/Ex3ParticipantVersionWorkerProcessor.java
@@ -183,8 +183,8 @@ public class Ex3ParticipantVersionWorkerProcessor implements ThrowingConsumer<Js
             }
 
             // Log message for our dashboards.
-            LOG.info("Exported participant version to study-specific project: appId=" + appId + ", studyId=" +
-                    studyId + ", healthCode=" + healthCode + ", version=" + versionNum);
+            LOG.info("Exported participant version to study-specific project: appId=" + appId + ", study=" + studyId +
+                    "-" + study.getName() + ", healthCode=" + healthCode + ", version=" + versionNum);
         }
 
         // Wait for all async tasks to be done.

--- a/src/main/java/org/sagebionetworks/bridge/exporter3/Exporter3WorkerProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter3/Exporter3WorkerProcessor.java
@@ -263,8 +263,8 @@ public class Exporter3WorkerProcessor implements ThrowingConsumer<JsonNode> {
             notification.putStudyRecordsItem(studyId, recordInfo);
 
             // Log message for our dashboards.
-            LOG.info("Exported upload to study-specific project: appId=" + appId + ", studyId=" + studyId +
-                    ", recordId=" + recordId);
+            LOG.info("Exported upload to study-specific project: appId=" + appId + ", study=" + studyId + "-" +
+                    study.getName() + ", recordId=" + recordId);
         }
 
         // Mark record as exported.


### PR DESCRIPTION
Some study IDs are just random strings. Study names aren't necessarily unique. This change logs the study ID with the study name so that we can have useful graphs while still having unique identifiers.