### PR TITLE
[IT-5233] Publish catalina.out to S3 and read both Tomcat log paths

### DIFF
--- a/ebextensions/logrotate-timer.config
+++ b/ebextensions/logrotate-timer.config
@@ -1,0 +1,32 @@
+###################################################################################################
+#### AL2023's logrotate.timer defaults to OnCalendar=daily, which caps how finely any logrotate.d
+#### rule can actually fire regardless of its own interval directive (see the `hourly` catalina.out
+#### rule in logrotate-tomcat.config) -- a stanza is only re-evaluated as often as the timer runs.
+#### This drop-in speeds the timer itself up to hourly so that rule is honored. It's safe for the
+#### platform's other logrotate.d rules too: raising how often logrotate *checks* doesn't make a
+#### `daily`/`weekly` stanza rotate any more often, since logrotate tracks each file's last-rotated
+#### date independently of how often it's asked to look.
+####
+#### Persistent=true catches the timer up immediately on boot if the instance was stopped through
+#### a scheduled firing time, instead of waiting up to an hour for the next calendar boundary.
+####
+#### A drop-in (rather than editing the shipped unit file directly) survives package updates and
+#### re-enables cleanly, since it layers on top of whatever unit the platform provides.
+###################################################################################################
+
+files:
+  "/etc/systemd/system/logrotate.timer.d/override.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      [Timer]
+      OnCalendar=
+      OnCalendar=hourly
+      Persistent=true
+
+commands:
+  "01_reload_systemd":
+    command: "systemctl daemon-reload"
+  "02_restart_logrotate_timer":
+    command: "systemctl restart logrotate.timer"

--- a/ebextensions/logrotate-tomcat.config
+++ b/ebextensions/logrotate-tomcat.config
@@ -4,13 +4,26 @@ files:
     owner: root
     group: root
     content: |
+      # Rotates the Tomcat catalina.out written by our rsyslog redirect (see tomcatlogs.config).
+      #
+      # hourly, not daily/size: Sumo Logic should never be more than an hour behind regardless of
+      # traffic volume. This also requires speeding up logrotate.timer itself (see
+      # logrotate-timer.config) -- an hourly stanza is only as fine-grained as how often the
+      # system actually re-checks it.
+      #
+      # dateext/dateformat: EB's publishlogs.d task dedupes purely by filename already seen in
+      # its local publish record, not by content -- it's built for one-shot immutable snapshots,
+      # not a live file it should keep re-checking. so the publish task
+      # sees a name it already published and skips the new content forever. A minute-resolution
+      # timestamp keeps every rotation's filename unique (matching publishlogs.config's
+      # catalina.out.* glob) and is easier to eyeball in the S3 bucket than a raw epoch.
       /var/log/tomcat/catalina.out {
-        daily
-        rotate 7
+        hourly
+        rotate 168
         missingok
         notifempty
         compress
-        delaycompress
         copytruncate
-        size 100M
+        dateext
+        dateformat .%Y-%m-%d-%H-%M
       }

--- a/ebextensions/publishlogs.config
+++ b/ebextensions/publishlogs.config
@@ -1,0 +1,21 @@
+###################################################################################################
+#### Adds Tomcat's catalina.out to Elastic Beanstalk's "publish logs to S3" task.
+####
+#### EB rotates a platform-defined set of logs to the environment's S3 bucket under
+#### resources/environments/logs/publish/<env-id>/<instance-id>/, and the Sumo Logic collectors
+#### ingest from that bucket. The AL2023 Tomcat 9 platform's default publish set does NOT include
+#### the application's catalina.out (only Tomcat's JULI catalina.<date>.log files), so application
+#### logs stopped reaching Sumo Logic after the AL2 -> AL2023 upgrade. This restores them by
+#### explicitly adding catalina.out (and its rotations) to the publish task.
+####
+#### AWS docs, "Extending the default log task configuration":
+####   https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.logging.html
+###################################################################################################
+
+files:
+  "/opt/elasticbeanstalk/tasks/publishlogs.d/catalina-out.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      /var/log/tomcat/catalina.out.*


### PR DESCRIPTION
    After the AL2 -> AL2023 upgrade the workers/exporter stopped logging to
    Sumo Logic. Two things combined: AL2023 runs Tomcat 9 (native log dir
    /var/log/tomcat9), and the platform's default S3 log-publication set no
    longer includes catalina.out, so the application log (written by our
    rsyslog redirect to /var/log/tomcat) stopped reaching the Sumo Logic
    collectors, which ingest from the EB S3 publish bucket. CloudWatch was
    unaffected because it read the file directly.

    Approach:

    - Add ebextensions/publishlogs.config to explicitly publish catalina.out
      restoring the Sumo Logic feed.
    - tomcatlogs.config: rsyslog keeps writing the single canonical
      /var/log/tomcat/catalina.out; the CloudWatch agent reads both
      /var/log/tomcat and /var/log/tomcat9, and BOTH stream into the same
      version-less /var/log/tomcat log group (the reusable group the *-infra
      stack provisions and attaches its metric-filter alarms to).

    The version-less /var/log/tomcat is intentionally the canonical path
    (*-infra dropped the version "for future reusability"); /var/log/tomcat9
    is read as a fallback for the platform's native Tomcat 9 dir.

    Rotation: EB's publishlogs.d task dedupes purely by filename already
    present in its local publish record, not by content or mtime -- it's built
    to publish one-shot immutable snapshots, not to keep re-checking a live
    file. Two consequences followed from the original IT-4976 logrotate rule:

    - catalina.out itself gets published exactly once, the first time the task
      sees it, and is skipped forever after -- its S3 object's Last-Modified
      stays frozen even while the file keeps growing on disk.
    - The rule also combined `daily` with `size 100M` -- these are mutually
      exclusive in logrotate, and size silently wins, so the file only ever
      rotated once it crossed 100M rather than on any predictable schedule.

    The actual fix:
    - dateext/dateformat gives every rotation a unique, minute-resolution
      timestamped filename (catalina.out.<year-month-day-hour-minute>.gz),
      matching publishlogs.config's catalina.out.* glob and mirroring the
      naming convention EB's own native log rotation already uses successfully.
    - hourly (instead of daily/size) bounds how far Sumo Logic can lag behind
      regardless of traffic volume. Since an hourly stanza is only as
      fine-grained as how often logrotate itself is invoked, and AL2023's
      logrotate.timer defaults to OnCalendar=daily, a systemd drop-in
      (logrotate-timer.config) speeds that timer up to hourly, resetting the
      accumulated OnCalendar list first (list-type directives are additive
      across a base unit and its drop-ins) so it doesn't end up firing on both
      schedules. Persistent=true catches the timer up on boot if the instance
      was stopped through a scheduled firing time. A drop-in survives package
      updates, unlike editing the shipped unit file directly. rotate 168 keeps
      roughly the same week of on-disk retention as the previous
      daily/rotate-7 config.

    Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>